### PR TITLE
set 0 nodes and processors by default

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -69,6 +69,8 @@ def summaryMessage(config, year, month, wallDuration, cpuDuration, numJobs):
         f'WallDuration: {wallDuration}\n'
         f'CpuDuration: {cpuDuration}\n'
         f'NumberOfJobs: {numJobs}\n'
+        f'Processors: {config.processors}\n'
+        f'NodeCount: {config.nodecount}\n'
         f'%%\n'
     )
     return output

--- a/python/KAPELConfig.py
+++ b/python/KAPELConfig.py
@@ -61,3 +61,8 @@ class KAPELConfig:
         # infrastructure info
         self.infrastructure_type = env.str("INFRASTRUCTURE_TYPE", "grid")
         self.infrastructure_description = env.str("INFRASTRUCTURE_DESCRIPTION", "APEL-KUBERNETES")
+
+        # optionally define number of nodes and processors. Should not be necessary to
+        # set a default of 0 here but see https://github.com/apel/apel/issues/241
+        self.nodecount = env.int("NODECOUNT", 0)
+        self.processors = env.int("PROCESSORS", 0)


### PR DESCRIPTION
Workaround for https://github.com/apel/apel/issues/241
Sets NodeCount and Processors to 0 by default, or value of config property if specified.