### PR TITLE
update for KSM 2.0 and bitnami prometheus 6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ APEL accounting for Kubernetes.
 
 ## Requirements
 - X509 certificate and key for publishing APEL records with ssmsend
-  - Note: ssmsend only uses the certificate for content signing, not TLS, so the DN of the certificate does not need to match any host name. It only needs to match the "Host DN" field in GOCDB for the gLite-APEL service.
+  - Note: ssmsend only uses the certificate for content signing, not TLS, so the DN of the certificate does not need to match any host name.
+    It only needs to match the "Host DN" field in GOCDB for the gLite-APEL service.
 - ssmsend container built using the provided Containerfile and pushed to an accessible registry server
 - kube-state-metrics and Prometheus (installation via [bitnami/kube-prometheus](https://bitnami.com/stack/prometheus-operator/helm) is recommended)
   - All pod metrics that are collected via kube-state-metrics will be used, so you must set `.Values.kube-state-metrics.namespaces`
@@ -12,7 +13,10 @@ APEL accounting for Kubernetes.
   - You may wish to set some of the collectors in `.Values.kube-state-metrics.kubeResources` to False to disable collection of
     unnecessary metrics and reduce data volume. Only the `pods` collector is required.
   - You should ensure that the Prometheus deployment is configured to use persistent storage so the collected metrics data will be
-    persisted for a sufficient period of time.
+    persisted for a sufficient period of time (e.g. at least a couple months).
+  - kube-state-metrics should be configured with `honorLabels: true`
+    - This is more intuitive, and set by default in the bitnami/kube-prometheus chart (see [#7690](https://github.com/bitnami/charts/issues/7690)),
+      but differs from the behaviour of the upstream kube-state-metrics community chart.
   - For large production deployments (examples are based on a cluster with about 125 nodes and 7000 cores):
     - Increase `.Values.prometheus.querySpec.timeout` (e.g. ~ 1800s) to allow long queries to succeed.
     - Apply sufficient resource requests and limits, e.g.
@@ -21,10 +25,10 @@ prometheus:
   resources:
     requests:
       cpu: "2000m"
-      memory: "16Gi"
+      memory: "32Gi"
     limits:
       cpu: "8000m"
-      memory: "32Gi"
+      memory: "64Gi"
 
 kube-state-metrics:
   resources:

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ APEL accounting for Kubernetes.
   - All pod metrics that are collected via kube-state-metrics will be used, so you must set `.Values.kube-state-metrics.namespaces`
     to ensure that accounting records are only published for pods in the appropriate namespace(s).
   - Pods must specify CPU resource requests in order to be accounted.
-  - You may wish to set some of the collectors in `.Values.kube-state-metrics.kubeResources` to False to disable collection of
-    unnecessary metrics and reduce data volume. Only the `pods` collector is required.
+  - You may wish to disable collection of some resources in `.Values.kube-state-metrics.kubeResources` to reduce the volume of unnecessary data.
+    Only the collection of `pods` resources is required.
   - You should ensure that the Prometheus deployment is configured to use persistent storage so the collected metrics data will be
     persisted for a sufficient period of time (e.g. at least a couple months).
   - kube-state-metrics should be configured with `honorLabels: true`
@@ -39,6 +39,9 @@ kube-state-metrics:
       cpu: 200m
       memory: 256Mi
 ```
+
+## Configuration
+See [values.yaml](chart/values.yaml) for the Helm chart values to configure.
 
 ## Helm chart installation
 The kapel Helm chart is available from [this Helm repository](https://rptaylor.github.io/kapel/).

--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -38,21 +38,17 @@ class QueryLogic:
         # On the CPU core side, some pods don't share all the same labels: pods that haven't yet gotten scheduled to a node don't have the node label,
         # so we filter out the rows where it's null with '{node != ""}'
 
-        # Note: Prometheus renames some labels from KSM, e.g. from 'pod' to 'exported_pod', the latter of which is the label we're interested in.
-        # The 'instance' and 'pod' labels in Prometheus actually represent the IP:port and name, respectively, of the KSM pod that Prometheus got the metric from.
-        # When KSM is redeployed (or if the KSM deployment has > 1 pod), the 'instance' and 'pod' labels may have different values,
-        # which would cause a label mismatch, so we use without to exclude them.
+        # The 'instance' label in Prometheus actually represents the IP and port of the KSM pod that Prometheus retrieved the metric from.
+        # When KSM is redeployed (or if the KSM deployment has > 1 pod), the 'instance' label may have different values,
+        # which would cause label matching problems, so we use without to exclude it.
         # Also, use the 'max' aggregation operator (which only takes a scalar) on the result of max_over_time
         # (which takes a range and returns a scalar), and as a result get the whole metric set. Finally, use group_left for many-to-one matching.
         # https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
         # https://prometheus.io/docs/prometheus/latest/querying/operators/#many-to-one-and-one-to-many-vector-matches
-
-        # Note some of these queries return duplicate results - without (instance, pod) does not seem to work properly.
-        # Would be very bad but rearrange() overwrites duplicates
-        self.cputime = f'(max_over_time(kube_pod_completion_time[{queryRange}]) - max_over_time(kube_pod_start_time[{queryRange}])) * on (exported_pod) group_left() max without (instance, pod) (max_over_time(kube_pod_container_resource_requests_cpu_cores{{node != ""}}[{queryRange}]))'
+        self.cputime = f'(max_over_time(kube_pod_completion_time[{queryRange}]) - max_over_time(kube_pod_start_time[{queryRange}])) * on (pod) group_left() max without (instance) (max_over_time(kube_pod_container_resource_requests{{resource="cpu", node != ""}}[{queryRange}]))'
         self.endtime = f'max_over_time(kube_pod_completion_time[{queryRange}])'
         self.starttime = f'max_over_time(kube_pod_start_time[{queryRange}])'
-        self.cores = f'max_over_time(kube_pod_container_resource_requests_cpu_cores{{node != ""}}[{queryRange}])'
+        self.cores = f'max_over_time(kube_pod_container_resource_requests{{resource="cpu", node != ""}}[{queryRange}])'
 
 def summary_message(config, year, month, wall_time, cpu_time, n_jobs, first_end, last_end):
     output = (
@@ -146,12 +142,12 @@ def get_gap_time_periods(start, end):
     return periods
 
 # Take a list of dicts from the prom query and construct a random-accessible dict (casting from string to float while we're at it) via generator.
-# (actually a list of tuples, so use dict() on the output) that can be referenced by the 'exported_pod' label as a key.
+# (actually a list of tuples, so use dict() on the output) that can be referenced by the 'pod' label as a key.
 # NB: this overwrites duplicate results if we get any from the prom query!
 def rearrange(x):
     for item in x:
         # this produces each of the (key, value) tuples in the list
-        yield item['metric']['exported_pod'], float(item['value'][1])
+        yield item['metric']['pod'], float(item['value'][1])
 
 # process a time period (do prom query, process data, write output)
 # takes a KAPELConfig object and one element of output from get_time_periods
@@ -173,7 +169,7 @@ def process_period(config, period):
     # iterate over each query (cputime, starttime, endtime, cores) producing raw_results['cputime'] etc.
     for query_name, query_string in vars(queries).items():
         # Each of these raw_results is a list of dicts. Each dict in the list represents an individual data point, and contains:
-        # 'metric': a dict of one or more key-value pairs of labels, one of which is the pod name ('exported_pod').
+        # 'metric': a dict of one or more key-value pairs of labels, one of which is the pod name.
         # 'value': a list in which the 0th element is the timestamp of the value, and 1th element is the actual value we're interested in.
         print(f'Executing {query_name} query: {query_string}')
         t1 = timer()

--- a/python/KAPELConfig.py
+++ b/python/KAPELConfig.py
@@ -26,7 +26,7 @@ class KAPELConfig:
         # that QUERY_START is precisely the beginning of a month in order to produce a complete summary record for that month which will take precedence over
         # any other records containing fewer jobs that may have already been published. The same applies for QUERY_END
         # matching the end of the month (unless it is the current month at the time of publishing, in which case a subsequent run in auto mode will eventually
-        # complete the records for this month).  So QUERY_START (and possibly QUERY_END) should look like e.g. '2021-02-01T00:00:00+00:00'
+        # complete the records for this month). So QUERY_START (and possibly QUERY_END) should look like e.g. '2021-02-01T00:00:00+00:00'
         if self.publishing_mode == "gap":
             self.query_start = env.datetime("QUERY_START")
             self.query_end = env.datetime("QUERY_END")

--- a/utils/test.py
+++ b/utils/test.py
@@ -10,7 +10,7 @@ API='/api/v1/query'
 TIMEOUT='500s'
 
 def doQueries(instant, duration):
-  CPUTIME_QUERY = f'(max_over_time(kube_pod_completion_time[{duration}]) - max_over_time(kube_pod_start_time[{duration}])) * on (exported_pod) group_left() max without (instance, pod) (max_over_time(kube_pod_container_resource_requests_cpu_cores{{node != ""}}[{duration}]))'
+  CPUTIME_QUERY = f'(max_over_time(kube_pod_completion_time[{duration}]) - max_over_time(kube_pod_start_time[{duration}])) * on (pod) group_left() max without (instance) (max_over_time(kube_pod_container_resource_requests_cpu_cores{{node != ""}}[{duration}]))'
   ENDTIME_QUERY = f'max_over_time(kube_pod_completion_time[{duration}])'
   STARTTIME_QUERY = f'max_over_time(kube_pod_start_time[{duration}])'
   CORES_QUERY = f'max_over_time(kube_pod_container_resource_requests_cpu_cores{{node != ""}}[{duration}])'
@@ -42,19 +42,19 @@ def doQueries(instant, duration):
 
 # These are lists of dicts.
 # Each dict in the list contains:
-# 'metric': a dict of key-value pairs of labels, one of which is the pod name (exported_pod)
+# 'metric': a dict of key-value pairs of labels, one of which is the pod name 
 # 'value': a list in which the 0th element is the timestamp of the value, 1th is the actual value we're interested in
   cputime_results = cputime_response.json()['data']['result']
   endtime_results = endtime_response.json()['data']['result']
   starttime_results = starttime_response.json()['data']['result']
   cores_results = cores_response.json()['data']['result']
 
-# construct random-accessible dicts (instead of lists of dicts) so we can reference by the exported_pod label.
+# construct random-accessible dicts (instead of lists of dicts) so we can reference by the pod label.
 # cast from string to number while we're at it.
-  cputime = {item['metric']['exported_pod']:float(item['value'][1]) for item in cputime_results}
-  endtime = {item['metric']['exported_pod']:float(item['value'][1]) for item in endtime_results}
-  starttime = {item['metric']['exported_pod']:float(item['value'][1]) for item in starttime_results}
-  cores = {item['metric']['exported_pod']:float(item['value'][1]) for item in cores_results}
+  cputime = {item['metric']['pod']:float(item['value'][1]) for item in cputime_results}
+  endtime = {item['metric']['pod']:float(item['value'][1]) for item in endtime_results}
+  starttime = {item['metric']['pod']:float(item['value'][1]) for item in starttime_results}
+  cores = {item['metric']['pod']:float(item['value'][1]) for item in cores_results}
 
   print(len(cputime))
   print(len(endtime))


### PR DESCRIPTION
- change PromQL query and logic for compatibility with breaking changes in KSM versions >= 2
  - in particular, the removal of `kube_pod_container_resource_requests_cpu_cores` ; see https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md#v200-alpha--2020-09-16
- the exported label behaviour has also changed (in the bitnami kube-prometheus chart v6.1.13,  which sets an intuitive but "non-standard" default value honorlabels: true for the KSM subchart: https://github.com/bitnami/charts/pull/7747 ). Now we need to use pod instead of exported_pod, which breaks compatibility with all prior data stored in the Prometheus data store :(  It may be necessary to publish all current records, and wipe out all stored data when upgrading, then start from a fresh empty data store.


The honorlabels change causes the output from a query such as `max_over_time(kube_pod_completion_time[8h])`, to change from e.g. 
```
{container="kube-state-metrics",  endpoint="http", exported_namespace="harvester",  exported_pod="grid-job-14868457-qc4jp", instance="10.233.96.2:8080",  job="kube-prometheus-kube-state-metrics", namespace="kube-prometheus",  pod="kube-prometheus-kube-state-metrics-7df685ff6f-rtg4j",  service="kube-prometheus-kube-state-metrics"} | 1653940601
```
to:
```
{container="kube-state-metrics",  endpoint="http", instance="10.233.87.156:8080",  job="kube-prometheus-kube-state-metrics", namespace="harvester",  pod="grid-job-14869085-4hdv5",  service="kube-prometheus-kube-state-metrics",  uid="97ff9f95-3c7c-4306-9509-7838147fce65"} | 1653942870
```




