### PR TITLE
use GA cron job API in chart version 0.1.18

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.17
+version: 0.1.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-cronjob


### PR DESCRIPTION
https://kubernetes.io/blog/2021/04/09/kubernetes-release-1.21-cronjob-ga/

https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/19-Graduate-CronJob-to-Stable

The new cronjob controller works better; no spec changes are required.

Using the new cron job requires k8s >= v1.21.
The old cron job controller  (v1beta1) is removed in k8s v 1.25 so this PR is required for kapel to run on k8s >= 1.25.
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25

fix #26 

