### PR TITLE
enable publishing manually defined records

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.18
+version: 0.1.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -46,6 +46,9 @@ spec:
             - name: apel-run-volume
               emptyDir:
                 sizeLimit: 50M
+            - name: manual-records
+              configMap:
+                name: {{ .Release.Name }}-manual-records
           initContainers:
             - name: {{ .Release.Name }}-processor
               image: library/python:3
@@ -72,6 +75,8 @@ spec:
               volumeMounts:
                 - name: apel-data-volume
                   mountPath: /srv/kapel
+                - name: manual-records
+                  mountPath: /srv/manual
           containers:
             - name: {{ .Release.Name }}-ssmsend
               image: {{ .Values.ssmsend.image_repository }}:{{ .Values.ssmsend.image_tag | default .Chart.AppVersion }}

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -50,7 +50,7 @@ spec:
               configMap:
                 name: {{ .Release.Name }}-manual-records
           initContainers:
-            - name: {{ .Release.Name }}-processor
+            - name: processor
               image: library/python:3
               resources:
                 {{- toYaml .Values.processor.resources | nindent 16 }}
@@ -78,7 +78,7 @@ spec:
                 - name: manual-records
                   mountPath: /srv/manual
           containers:
-            - name: {{ .Release.Name }}-ssmsend
+            - name: ssmsend
               image: {{ .Values.ssmsend.image_repository }}:{{ .Values.ssmsend.image_tag | default .Chart.AppVersion }}
               resources:
                 {{- toYaml .Values.ssmsend.resources | nindent 16 }}

--- a/chart/templates/manual-publishing-configmap.yaml
+++ b/chart/templates/manual-publishing-configmap.yaml
@@ -1,0 +1,8 @@
+{{- /* Intentionally empty. Manually edit the configmap to add records for the manual publishing procedure. */ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-manual-records
+  labels:
+    {{- include "kapel.labels" . | nindent 4 }}
+data:

--- a/docs/manual_publishing.md
+++ b/docs/manual_publishing.md
@@ -1,0 +1,45 @@
+# Procedure for publishing records manually
+
+Sometimes it may be necessary to publish manually-defined records instead of querying Prometheus to get accounting records.
+There is a ConfigMap created by the Helm chart for this, which is named `kapel-manual-records` by default.
+Manually edit that ConfigMap (e.g. `kubectl edit`) and insert the accounting information that you want to publish.
+The keys of the ConfigMap are arbitrary and you can define as many as needed.
+For example it could look like this:
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kapel-manual-records
+  namespace: kapel
+data:
+  OctoberSummaryCorrection: |
+    APEL-summary-job-message: v0.2
+    Site: CA-EXAMPLE-T2
+    Month: 10
+    Year: 2022
+    VO: atlas
+    SubmitHost: k8s.example.org:6443/harvester
+    InfrastructureType: grid
+    ServiceLevelType: si2k
+    ServiceLevel: 2975.0
+    WallDuration: 188517
+    CpuDuration: 188517
+    NumberOfJobs: 383
+    Processors: 0
+    NodeCount: 0
+    EarliestEndTime: 1664582401
+    LatestEndTime: 1667260774
+    %%
+  OctoberSyncCorrection: |
+    APEL-sync-message: v0.1
+    Site: CA-EXAMPLE-T2
+    SubmitHost: k8s.example.org:6443/harvester
+    NumberOfJobs: 383
+    Month: 10
+    Year: 2022
+    %%
+```
+
+Then wait for the next scheduled CronJob run to publish the records, or manually create a Job from the CronJob.
+Afterwards, __you must remove all contents and keys of the data field__ of the ConfigMap in order to return to the normal querying mode.
+Note that upgrading the Helm chart will erase any manually-defined records and reset this ConfigMap to the default empty state, for normal operation.

--- a/docs/manual_publishing.md
+++ b/docs/manual_publishing.md
@@ -4,7 +4,7 @@ Sometimes it may be necessary to publish manually-defined records, instead of qu
 There is a ConfigMap created by the Helm chart for this, which is named `kapel-manual-records` by default.
 Manually edit that ConfigMap (e.g. `kubectl edit`) and insert the accounting information that you want to publish.
 The keys of the ConfigMap are arbitrary and you can define as many as needed.
-For example it could look like this:
+For example it could look something like this:
 ```
 apiVersion: v1
 kind: ConfigMap

--- a/docs/manual_publishing.md
+++ b/docs/manual_publishing.md
@@ -1,6 +1,6 @@
 # Procedure for publishing records manually
 
-Sometimes it may be necessary to publish manually-defined records instead of querying Prometheus to get accounting records.
+Sometimes it may be necessary to publish manually-defined records, instead of querying Prometheus to get accounting records.
 There is a ConfigMap created by the Helm chart for this, which is named `kapel-manual-records` by default.
 Manually edit that ConfigMap (e.g. `kubectl edit`) and insert the accounting information that you want to publish.
 The keys of the ConfigMap are arbitrary and you can define as many as needed.

--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -266,7 +266,7 @@ def main(envFile):
     
     if found_records:
       print('Manually-defined records detected in ' + manual_path)
-      dirq = QueueSimple(str(config.output_path))
+      dirq = QueueSimple(str(cfg.output_path))
       for record in found_records:
         added_file = dirq.add_path(record)
         print(f'Adding record from {record} to {config.output_path}/{added_file}:')

--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -274,6 +274,7 @@ def main(envFile):
       for record in found_records:
         src_file = join(manual_path, record)
         dst_file = join(dest_dir, record)
+        print(f'Copying file from {src_file} to {dst_file}')
         copyfile(src_file, dst_file)
         added_file = join(cfg.output_path, dirq.add_path(dst_file))
         print(f'Adding record from {dst_file} to {added_file}:')

--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -261,7 +261,7 @@ def main(envFile):
     cfg = KAPELConfig(envFile)
 
     # look for manually-defined records, from the manual configmap
-    manual_path = '/srv/manual'
+    manual_path = '/srv/kapel/manual'
     found_records = [join(manual_path, f) for f in listdir(manual_path) if isfile(join(manual_path, f))]
     
     if found_records:

--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -275,9 +275,9 @@ def main(envFile):
         src_file = join(manual_path, record)
         dst_file = join(dest_dir, record)
         copyfile(src_file, dst_file)
-        added_file = dirq.add_path(dst_file)
-        print(f'Adding record from {dst_file} to {cfg.output_path}/{added_file}:')
-        print('--------------------------------\n' + Path(dst_file).read_text() + '--------------------------------')
+        added_file = join(cfg.output_path, dirq.add_path(dst_file))
+        print(f'Adding record from {dst_file} to {added_file}:')
+        print('--------------------------------\n' + Path(added_file).read_text() + '--------------------------------')
 
     else:
       # No manual records detected, do normal procedure

--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -276,7 +276,7 @@ def main(envFile):
         dst_file = join(dest_dir, record)
         copyfile(src_file, dst_file)
         added_file = dirq.add_path(dst_file)
-        print(f'Adding record from {src_file} to {dest_dir}/{added_file}:')
+        print(f'Adding record from {dst_file} to {cfg.output_path}/{added_file}:')
         print('--------------------------------\n' + Path(dst_file).read_text() + '--------------------------------')
 
     else:

--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -277,7 +277,7 @@ def main(envFile):
         copyfile(src_file, dst_file)
         added_file = dirq.add_path(dst_file)
         print(f'Adding record from {src_file} to {dest_dir}/{added_file}:')
-        print('--------------------------------\n' + Path(record).read_text() + '--------------------------------')
+        print('--------------------------------\n' + Path(dst_file).read_text() + '--------------------------------')
 
     else:
       # No manual records detected, do normal procedure


### PR DESCRIPTION
Configmap for manually-defined records will always exist and be mounted, but is empty by default.

If the processor finds files from it it will add those with dirq instead of querying prometheus.

Shorten container names too.