### PR TITLE
set ttlSecondsAfterFinished to large value by default

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.19
+version: 0.1.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -14,6 +14,7 @@ spec:
     spec:
       # Allow up to 12 hours and 2 pod retries for job completion (should be less than cron frequency)
       activeDeadlineSeconds: 43200
+      ttlSecondsAfterFinished: {{ .Values.cronjob.ttlSecondsAfterFinished }}
       backoffLimit: 2
       template:
         spec:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,6 +1,7 @@
 cronjob:
   schedule: "@daily"
   priorityClassName: ""
+  ttlSecondsAfterFinished: 7776000
 
 # If true, /cvmfs/grid.cern.ch/etc/grid-security/certificates/ will be mounted as a hostPath volume.
 # If false, you will need to set up an alternative way of providing the ca-policy-* packages and CRLs in the ssmsend container.


### PR DESCRIPTION
The successful and failed job history limits work to retain jobs.
However on a large busy cluster, while the jobs are retained, the pods for those jobs are deleted, losing the logs.
OTOH on a small dev cluster, both the jobs and their pods are retained. Not sure why but setting the ttlSecondsAfterFinished to a large value (90 days by default) could help.