### PR TITLE
Select namespace via prom query instead of via prom config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ KAPEL is APEL accounting for Kubernetes.
   - Note: ssmsend only uses the certificate for content signing, not TLS, so the DN of the certificate does not need to match any host name.
     It only needs to match the "Host DN" field in GOCDB for the gLite-APEL service.
 - kube-state-metrics and Prometheus (installing both via [bitnami/kube-prometheus](https://bitnami.com/stack/prometheus-operator/helm) is recommended)
-  - All pod metrics that are collected via kube-state-metrics will be used, so you must set `.Values.kube-state-metrics.namespaces`
-    to ensure that accounting records are only published for pods in the appropriate namespace(s).
-  - Pods must specify CPU resource requests in order to be accounted.
   - You may wish to disable collection of some resources in `.Values.kube-state-metrics.kubeResources` to reduce the volume of unnecessary data.
     Only the collection of `pods` resources is required.
   - You should ensure that the Prometheus deployment is configured to use persistent storage so the collected metrics data will be
@@ -19,6 +16,9 @@ KAPEL is APEL accounting for Kubernetes.
   - For large production deployments (examples are based on a cluster with about 125 nodes and 7000 cores):
     - Increase `.Values.prometheus.querySpec.timeout` (e.g. ~ 1800s) to allow long queries to succeed.
     - Apply sufficient CPU and memory resource requests and limits.
+
+Pods must specify CPU resource requests in order to be accounted. All pods in a specified namespace will be accounted.
+To do accounting for different projects in multiple namespaces, a KAPEL chart can be installed and configured for each one.
 
 ## Configuration
 - See [kube-prometheus-example.yaml](docs/kube-prometheus-example.yaml) for an example values file to use for installation of the Bitnami kube-prometheus Helm chart.

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.21
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,6 +25,9 @@ processor:
   config: |
     SITE_NAME: "EXAMPLE-T2"
     SUBMIT_HOST: "k8s.example.org:6443/namespace"
+    NAMESPACE: "harvester"
+    VO_NAME: "atlas"
+    BENCHMARK_VALUE: "15.0"
   # name of git branch to use
   deploy_branch: "prod"
 

--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -52,10 +52,10 @@ class QueryLogic:
         # (which takes a range and returns a scalar), and as a result get the whole metric set. Finally, use group_left for many-to-one matching.
         # https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
         # https://prometheus.io/docs/prometheus/latest/querying/operators/#many-to-one-and-one-to-many-vector-matches
-        self.cputime = f'(max_over_time(kube_pod_completion_time[{queryRange}]) - max_over_time(kube_pod_start_time[{queryRange}])) * on (pod) group_left() max without (instance, node) (max_over_time(kube_pod_container_resource_requests{{resource="cpu", node != ""}}[{queryRange}]))'
-        self.endtime = f'max_over_time(kube_pod_completion_time[{queryRange}])'
-        self.starttime = f'max_over_time(kube_pod_start_time[{queryRange}])'
-        self.cores = f'max_over_time(kube_pod_container_resource_requests{{resource="cpu", node != ""}}[{queryRange}])'
+        self.cputime = f'(max_over_time(kube_pod_completion_time{{namespace="{self.namespace}"}}[{queryRange}]) - max_over_time(kube_pod_start_time{{namespace="{self.namespace}"}}[{queryRange}])) * on (pod) group_left() max without (instance, node) (max_over_time(kube_pod_container_resource_requests{{resource="cpu", node != "", namespace="{self.namespace}"}}[{queryRange}]))'
+        self.endtime = f'max_over_time(kube_pod_completion_time{{namespace="{self.namespace}"}}[{queryRange}])'
+        self.starttime = f'max_over_time(kube_pod_start_time{{namespace="{self.namespace}"}}[{queryRange}])'
+        self.cores = f'max_over_time(kube_pod_container_resource_requests{{resource="cpu", node != "", namespace="{self.namespace}"}}[{queryRange}])'
 
 def summary_message(config, year, month, wall_time, cpu_time, n_jobs, first_end, last_end):
     output = (

--- a/python/KAPELConfig.py
+++ b/python/KAPELConfig.py
@@ -17,6 +17,9 @@ class KAPELConfig:
         # The default behaviour ("auto" mode) is to publish records for the previous month, and up to the current day of the current month.
         self.publishing_mode = env.str("PUBLISHING_MODE", "auto")
 
+        # The Kubernetes namespace to query. Only pods in this namespace will be accounted.
+        self.namespace = env.str("NAMESPACE")
+
         # If PUBLISHING_MODE is "gap" instead, then a fixed time period will be queried instead and we need the start and end to be specified.
         # Format: ISO 8601, like "2020-12-20T07:20:50.52Z", to avoid complications with time zones and leap seconds.
         # Timezone should be specified, and it should be UTC for consistency with the auto mode publishing.


### PR DESCRIPTION
fix https://github.com/rptaylor/kapel/issues/38

Add NAMESPACE as a required environment variable for configuration. This way multiple KAPEL instances can run, each accounting different namespaces.