### PR TITLE
indicate required config with comments

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -21,13 +21,13 @@ processor:
       cpu: "0.5"
       memory: "500Mi"
   # See KAPELConfig.py for full details on required configuration.
-  # Along with SITE_NAME and SUBMIT_HOST, you will also need to define BENCHMARK_VALUE (the HS06 score) and VO_NAME.
+  # Along with SITE_NAME and SUBMIT_HOST, you will also need to define BENCHMARK_VALUE, NAMESPACE, and VO_NAME.
   config: |
     SITE_NAME: "EXAMPLE-T2"
     SUBMIT_HOST: "k8s.example.org:6443/namespace"
-    NAMESPACE: "harvester"
-    VO_NAME: "atlas"
-    BENCHMARK_VALUE: "15.0"
+    #BENCHMARK_VALUE: "15.0"
+    #NAMESPACE: "harvester"
+    #VO_NAME: "atlas"
   # name of git branch to use
   deploy_branch: "prod"
 


### PR DESCRIPTION
But don't define default values. This way the requirement is more explicit, less risk of accidentally using inappropriate defaults.