### PR TITLE
update to KAPEL v0.2.0 with per-namespace publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # KAPEL 
-KAPEL is APEL accounting for Kubernetes.
+KAPEL is container-native APEL accounting for Kubernetes.
+- Lightweight and stateless (data storage is handled by Prometheus).
+- Supports two publishing modes:
+  - 'auto' mode to publish the current month and previous month.
+  - 'gap' mode to (re)publish an arbitrary fixed time period.
+- Supports two data source modes:
+  - Normally, pod data is retrieved from Prometheus.
+  - For manual corrections, you can supply the accounting data to be published yourself.
 
 ## Requirements
 - X509 certificate and key for publishing APEL records with ssmsend

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ KAPEL is APEL accounting for Kubernetes.
   - Note: ssmsend only uses the certificate for content signing, not TLS, so the DN of the certificate does not need to match any host name.
     It only needs to match the "Host DN" field in GOCDB for the gLite-APEL service.
 - kube-state-metrics and Prometheus (installing both via [bitnami/kube-prometheus](https://bitnami.com/stack/prometheus-operator/helm) is recommended)
-  - All pod metrics that are collected via kube-state-metrics will be used, so you must set `.Values.kube-state-metrics.namespaces`
-    to ensure that accounting records are only published for pods in the appropriate namespace(s).
-  - Pods must specify CPU resource requests in order to be accounted.
   - You may wish to disable collection of some resources in `.Values.kube-state-metrics.kubeResources` to reduce the volume of unnecessary data.
     Only the collection of `pods` resources is required.
   - You should ensure that the Prometheus deployment is configured to use persistent storage so the collected metrics data will be
@@ -19,6 +16,9 @@ KAPEL is APEL accounting for Kubernetes.
   - For large production deployments (examples are based on a cluster with about 125 nodes and 7000 cores):
     - Increase `.Values.prometheus.querySpec.timeout` (e.g. ~ 1800s) to allow long queries to succeed.
     - Apply sufficient CPU and memory resource requests and limits.
+
+Pods must specify CPU resource requests in order to be accounted. All pods in a specified namespace will be accounted.
+To do accounting for different projects in multiple namespaces, a KAPEL chart can be installed and configured for each one.
 
 ## Configuration
 - See [kube-prometheus-example.yaml](docs/kube-prometheus-example.yaml) for an example values file to use for installation of the Bitnami kube-prometheus Helm chart.

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.20
+version: 0.1.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.19
+version: 0.1.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.21
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.20
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # For the purposes of KAPEL this is the ssmsend version.
-appVersion: 3.2.1
+appVersion: 3.3.1

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -14,6 +14,7 @@ spec:
     spec:
       # Allow up to 12 hours and 2 pod retries for job completion (should be less than cron frequency)
       activeDeadlineSeconds: 43200
+      ttlSecondsAfterFinished: {{ .Values.cronjob.ttlSecondsAfterFinished }}
       backoffLimit: 2
       template:
         spec:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -21,13 +21,13 @@ processor:
       cpu: "0.5"
       memory: "500Mi"
   # See KAPELConfig.py for full details on required configuration.
-  # Along with SITE_NAME and SUBMIT_HOST, you will also need to define BENCHMARK_VALUE (the HS06 score) and VO_NAME.
+  # Along with SITE_NAME and SUBMIT_HOST, you will also need to define BENCHMARK_VALUE, NAMESPACE, and VO_NAME.
   config: |
     SITE_NAME: "EXAMPLE-T2"
     SUBMIT_HOST: "k8s.example.org:6443/namespace"
-    NAMESPACE: "harvester"
-    VO_NAME: "atlas"
-    BENCHMARK_VALUE: "15.0"
+    #BENCHMARK_VALUE: "15.0"
+    #NAMESPACE: "harvester"
+    #VO_NAME: "atlas"
   # name of git branch to use
   deploy_branch: "prod"
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,6 +25,9 @@ processor:
   config: |
     SITE_NAME: "EXAMPLE-T2"
     SUBMIT_HOST: "k8s.example.org:6443/namespace"
+    NAMESPACE: "harvester"
+    VO_NAME: "atlas"
+    BENCHMARK_VALUE: "15.0"
   # name of git branch to use
   deploy_branch: "prod"
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,6 +1,7 @@
 cronjob:
   schedule: "@daily"
   priorityClassName: ""
+  ttlSecondsAfterFinished: 7776000
 
 # If true, /cvmfs/grid.cern.ch/etc/grid-security/certificates/ will be mounted as a hostPath volume.
 # If false, you will need to set up an alternative way of providing the ca-policy-* packages and CRLs in the ssmsend container.

--- a/misc/notes.md
+++ b/misc/notes.md
@@ -5,8 +5,8 @@
 
 # Build and push ssmsend container
 ```
-registry=<example.org>
-tag=<vX.Y.Z>
+registry=<example.org>  # e.g. "git.computecanada.ca:4567/rptaylor/misc"
+tag=<X.Y.Z>             # e.g. "3.3.1"
 
 buildah bud --squash -t ssmsend https://raw.githubusercontent.com/rptaylor/kapel/master/ssmsend-build/Containerfile
 imageid=`buildah images --format '{{.ID}}' ssmsend`

--- a/misc/notes.md
+++ b/misc/notes.md
@@ -15,7 +15,11 @@ buildah push $imageid $registry/ssmsend:$tag
 ```
 
 # Build and publish Helm chart to repository
-```
-helm package chart/
-helm repo index --url  https://rptaylor.github.io/kapel/  .
-```
+- First remember to update Chart.yaml with a new version (potentially appVersion too)
+- Copy the chart dir out of the git repo
+- `git checkout gh-pages`
+- Move the chart dir into the git repo
+- `helm package chart/`
+- `rm -rf chart/`
+- `helm repo index .`
+- git add, commit, push

--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -263,7 +263,6 @@ def process_period(config, period):
     print('--------------------------------\n' + sync_output + '--------------------------------')
 
 def main(envFile):
-    # TODO: need error handling if env file doesn't exist. See https://github.com/theskumar/python-dotenv/issues/297
     print(f'Starting KAPEL processor: {__file__} with envFile {envFile} at {datetime.datetime.now(tz=datetime.timezone.utc).isoformat()}')
     cfg = KAPELConfig(envFile)
 

--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -52,10 +52,10 @@ class QueryLogic:
         # (which takes a range and returns a scalar), and as a result get the whole metric set. Finally, use group_left for many-to-one matching.
         # https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
         # https://prometheus.io/docs/prometheus/latest/querying/operators/#many-to-one-and-one-to-many-vector-matches
-        self.cputime = f'(max_over_time(kube_pod_completion_time[{queryRange}]) - max_over_time(kube_pod_start_time[{queryRange}])) * on (pod) group_left() max without (instance, node) (max_over_time(kube_pod_container_resource_requests{{resource="cpu", node != ""}}[{queryRange}]))'
-        self.endtime = f'max_over_time(kube_pod_completion_time[{queryRange}])'
-        self.starttime = f'max_over_time(kube_pod_start_time[{queryRange}])'
-        self.cores = f'max_over_time(kube_pod_container_resource_requests{{resource="cpu", node != ""}}[{queryRange}])'
+        self.cputime = f'(max_over_time(kube_pod_completion_time{{namespace="{self.namespace}"}}[{queryRange}]) - max_over_time(kube_pod_start_time{{namespace="{self.namespace}"}}[{queryRange}])) * on (pod) group_left() max without (instance, node) (max_over_time(kube_pod_container_resource_requests{{resource="cpu", node != "", namespace="{self.namespace}"}}[{queryRange}]))'
+        self.endtime = f'max_over_time(kube_pod_completion_time{{namespace="{self.namespace}"}}[{queryRange}])'
+        self.starttime = f'max_over_time(kube_pod_start_time{{namespace="{self.namespace}"}}[{queryRange}])'
+        self.cores = f'max_over_time(kube_pod_container_resource_requests{{resource="cpu", node != "", namespace="{self.namespace}"}}[{queryRange}])'
 
 def summary_message(config, year, month, wall_time, cpu_time, n_jobs, first_end, last_end):
     output = (

--- a/python/KAPELConfig.py
+++ b/python/KAPELConfig.py
@@ -17,6 +17,9 @@ class KAPELConfig:
         # The default behaviour ("auto" mode) is to publish records for the previous month, and up to the current day of the current month.
         self.publishing_mode = env.str("PUBLISHING_MODE", "auto")
 
+        # The Kubernetes namespace to query. Only pods in this namespace will be accounted.
+        self.namespace = env.str("NAMESPACE")
+
         # If PUBLISHING_MODE is "gap" instead, then a fixed time period will be queried instead and we need the start and end to be specified.
         # Format: ISO 8601, like "2020-12-20T07:20:50.52Z", to avoid complications with time zones and leap seconds.
         # Timezone should be specified, and it should be UTC for consistency with the auto mode publishing.

--- a/ssmsend-build/Containerfile
+++ b/ssmsend-build/Containerfile
@@ -7,5 +7,5 @@ RUN yum install -y epel-release
 RUN yum install -y https://repository.egi.eu/sw/production/umd/4/centos7/x86_64/updates/umd-release-4.1.3-1.el7.centos.noarch.rpm
 # because UMD repo does not use HTTPS for GPG key
 RUN rpm --import https://repository.egi.eu/sw/production/umd/UMD-RPM-PGP-KEY
-RUN yum install -y python-dirq python-argo-ams-library https://github.com/apel/ssm/releases/download/3.2.1-1/apel-ssm-3.2.1-1.el7.noarch.rpm
+RUN yum install -y python-dirq python-argo-ams-library https://github.com/apel/ssm/releases/download/3.3.1-1/apel-ssm-3.3.1-1.el7.noarch.rpm
 RUN yum clean all


### PR DESCRIPTION
Now a KAPEL installation selects a configurable namespace to do accounting for, instead of relying on KSM configuration for that.