### PR TITLE
Feature/helm chart use gratia image

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ KAPEL is container-native Kubernetes accounting, for APEL and Gratia.
   - For large production deployments (examples are based on a cluster with about 125 nodes and 7000 cores):
     - Increase `.Values.prometheus.querySpec.timeout` (e.g. ~ 1800s) to allow long queries to succeed.
     - Apply sufficient CPU and memory resource requests and limits.
-  - If Prometheus is configured to require authentication, configure `.Values.processor.prometheus_auth` to specify an appropriate kubernetes
-    secret containing authentication information.
 
-Pods must specify CPU resource requests in order to be accounted. All pods in a specified namespace will be accounted.
+In order to be accounted, pods must specify CPU resource requests, and remain registered in Completed state on the cluster for a period of time when they finish.
+All pods in a specified namespace will be accounted.
 To do accounting for different projects in multiple namespaces, a KAPEL chart can be installed and configured for each one.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ KAPEL is container-native APEL accounting for Kubernetes.
 - Supports two data source modes:
   - Normally, pod data is retrieved from Prometheus.
   - For manual corrections, you can supply the accounting data to be published yourself.
+- Supports two data outlets:
+  - "ssmsend" publishes records to APEL via ssmsend
+  - "gratia" publishes records to [GRACC](https://gracc.opensciencegrid.org/) via 
+    [Gratia](https://github.com/opensciencegrid/gratia-probe/)
 
 ## Requirements
 - X509 certificate and key for publishing APEL records with ssmsend
@@ -23,6 +27,8 @@ KAPEL is container-native APEL accounting for Kubernetes.
   - For large production deployments (examples are based on a cluster with about 125 nodes and 7000 cores):
     - Increase `.Values.prometheus.querySpec.timeout` (e.g. ~ 1800s) to allow long queries to succeed.
     - Apply sufficient CPU and memory resource requests and limits.
+  - If Prometheus is configured to require authentication, configure `.Values.processor.prometheus_auth` to specify an appropriate kubernetes
+    secret containing authentication information.
 
 Pods must specify CPU resource requests in order to be accounted. All pods in a specified namespace will be accounted.
 To do accounting for different projects in multiple namespaces, a KAPEL chart can be installed and configured for each one.
@@ -34,3 +40,5 @@ To do accounting for different projects in multiple namespaces, a KAPEL chart ca
 
 ## Helm chart installation
 The KAPEL Helm chart is available from [this Helm repository](https://rptaylor.github.io/kapel/).
+
+See the [Helm Chart README](chart/README.md) for additional information.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # KAPEL 
-KAPEL is container-native APEL accounting for Kubernetes.
+KAPEL is container-native Kubernetes accounting, for APEL and Gratia.
 - Lightweight and stateless (data storage is handled by Prometheus).
 - Supports two publishing modes:
-  - 'auto' mode to publish the current month and previous month.
-  - 'gap' mode to (re)publish an arbitrary fixed time period.
+  - "auto" mode to publish the current month and previous month.
+  - "gap" mode to (re)publish an arbitrary fixed time period.
 - Supports two data source modes:
   - Normally, pod data is retrieved from Prometheus.
   - For manual corrections, you can supply the accounting data to be published yourself.
 - Supports two data outlets:
-  - "ssmsend" publishes records to APEL via ssmsend
-  - "gratia" publishes records to [GRACC](https://gracc.opensciencegrid.org/) via 
-    [Gratia](https://github.com/opensciencegrid/gratia-probe/)
+  - "ssmsend" mode to publish records to [APEL](https://apel.github.io/) via [SSM](https://github.com/apel/ssm).
+  - "gratia" mode to publish records to [GRACC](https://gracc.opensciencegrid.org/) via
+    [Gratia](https://github.com/opensciencegrid/gratia-probe/).
 
 ## Requirements
-- X509 certificate and key for publishing APEL records with ssmsend
+- For ssmsend mode: X509 certificate and key to publish APEL records
   - Note: ssmsend only uses the certificate for content signing, not TLS, so the DN of the certificate does not need to match any host name.
     It only needs to match the "Host DN" field in GOCDB for the gLite-APEL service.
 - kube-state-metrics and Prometheus (installing both via [bitnami/kube-prometheus](https://bitnami.com/stack/prometheus-operator/helm) is recommended)

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1-6
+version: 0.2.1-7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: kapel
-description: APEL accounting for Kubernetes
+name: kapel-gratia
+description: APEL and Gratia accounting for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.1-rc1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1-rc1
+version: 0.2.1-4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1-4
+version: 0.2.1-5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: kapel-gratia
+name: kapel
 description: APEL and Gratia accounting for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1-7
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1-5
+version: 0.2.1-6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,7 +1,7 @@
 # Kuantifier Helm Chart
 
-Kuantifier is installed and configured via helm chart. You must [install helm](https://helm.sh/docs/intro/install/) prior to 
-configuring and installing Kuantifier in your kubernetes cluster.
+Kuantifier is installed and configured via a Helm chart. You must [install helm](https://helm.sh/docs/intro/install/) prior to 
+configuring and installing Kuantifier in your Kubernetes cluster.
 
 ## Installation
 The Kuantifier Helm Chart is hosted at the OSG Harbor [OCI registry](https://helm.sh/docs/topics/registries/). To find the latest version of 
@@ -13,13 +13,13 @@ Then [install](https://helm.sh/docs/helm/helm_install/) it:
 
     helm install kuantifier oci://hub.opensciencegrid.org/iris-hep/kuantifier --version <latest-version> --values my-values.yaml
 
-Or [upgrade] an existing installation with a new helm chart version or set of configuration values:
+Or [upgrade] an existing installation with a new Helm chart version or set of configuration values:
 
     helm upgrade kuantifier oci://hub.opensciencegrid.org/iris-hep/kuantifier --version <latest-version> --values my-values.yaml
 
 ## Configuration
 
-Helm charts are configured via a yaml [configuration file](https://helm.sh/docs/chart_template_guide/values_files/). The default
+Helm charts are configured via a YAML [configuration file](https://helm.sh/docs/chart_template_guide/values_files/). The default
 configuration for Kuantifier is found at [values.yaml](./values.yaml). A custom values.yaml may be applied to a chart during
 installation or upgrade via the `--values` or `-f` helm command line option. The parameters of Kuantifier's values.yaml are documented
 below.
@@ -28,24 +28,24 @@ below.
 
 #### General Configuration
 * `.Values.outputFormat`: The outlet to report records to. Supports two values:
-  * `"ssmsend"`: Output to APEL via SSMSend.
+  * `"ssmsend"`: Output to APEL via SSM.
   * `"gratia"`: Output to [GRACC](https://gracc.opensciencegrid.org/) via 
     [Gratia](https://github.com/opensciencegrid/gratia-probe/).
 * `.Values.cronjob`: Configuration for the Kubernetes [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)
   object that periodically runs Kuantifier.
   * `.schedule`: Cron expression for scheduling the CronJob
   * `.priorityClassName`: [Priority Class](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) for the
-    pods that run the kuantifier job.
+    pods that run the Kuantifier job.
   * `.ttlSecondsAfterFinished`: Duration to persist completed pods after completion. 
 * `.Values.pspName`: If specified, a [Pod Security Policy](https://kubernetes.io/docs/concepts/security/pod-security-policy/).
     name to use. Deprecated in newer versions of Kubernetes.
 * `.Values.runAsNonRoot`: If true, run the pod as a [non-root user](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
 
-* `.Values.dataVolumeSize`: The size of the volume where Kuantifier stores its intermediate results between querying prometheus
+* `.Values.dataVolumeSize`: The size of the volume where Kuantifier stores its intermediate results between querying Prometheus
   and outputting to an external service. Note that Gratia output may require a significantly larger data volume size, as it operates
   on non-summarized records.
 
-* `.Values.processor`: Configuration for the container that queries Prometheus to generate Job metrics records.
+* `.Values.processor`: Configuration for the container that queries Prometheus to generate Job metric records.
   * `.image_repository`: Docker image repository from which to pull the processor image.
   * `.image_tag`: Optionally specify an image version.
   * `.image_pull_policy`: [Image Pull Policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) for the processor container.
@@ -57,9 +57,9 @@ below.
     * `SITE_NAME`: The name of the site being reported on.
     * `SUBMIT_HOST`: Uniquely identifying name for the cluster.
     * `VO_NAME`: VO of jobs.
-    * `BENCHMARK_VALUE`: Only required for SSMSend output.
+    * `BENCHMARK_VALUE`: The value to use for normalizing to CPU performance - for APEL accounting.
   * `.prometheus_auth`: If your Prometheus instance is configured to require [Authentication](https://prometheus.io/docs/prometheus/latest/configuration/https/)
-    from within the cluster, specify a Secret containing a value for the Authentication header.
+    from within the cluster, specify a Secret containing a value for the authentication header.
  
 #### Gratia Output Configuration
 
@@ -68,15 +68,15 @@ The following values only apply if `.Values.outputFormat` equals `"gratia"`:
 * `.Values.gratia`: Configuration for the container that outputs job records to GRACC.
   * `.image_repository`: Docker image repository from which to pull the Gratia output image.
   * `.image_tag`: Optionally specify an image version.
-  * `.resources`: Resource requests and limits for the gratia output container.
-  * `.config`: Environment variables for the gratia output container. Currently, it is strongly recommended to use the default.
+  * `.resources`: Resource requests and limits for the Gratia output container.
+  * `.config`: Environment variables for the Gratia output container. Currently, it is strongly recommended to use the default.
 
 #### SSMSend Output Configuration
 
 The following values only apply if `.Values.outputFormat` equals `"ssmsend"`:
 
 * `.Values.ssmsend`: Configuration for the container that outputs job records to APEL.
-  * `.image_repository`: Docker image repository from which to pull the ssmsend output image.
+  * `.image_repository`: Docker image repository from which to pull the SSM output image.
   * `.image_tag`: Optionally specify an image version.
-  * `.resources`: Resource requests and limits for the ssmsend output container.
+  * `.resources`: Resource requests and limits for the SSM output container.
   * `.x509cert` and `.x509key`: Base64-encoded public cert and private key to authenticate to APEL.

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,0 +1,82 @@
+# Kuantifier Helm Chart
+
+Kuantifier is installed and configured via helm chart. You must [install helm](https://helm.sh/docs/intro/install/) prior to 
+configuring and installing Kuantifier in your kubernetes cluster.
+
+## Installation
+The Kuantifier Helm Chart is hosted at the OSG Harbor [OCI registry](https://helm.sh/docs/topics/registries/). To find the latest version of 
+the Kuantifier helm chart:
+    
+    helm show chart oci://hub.opensciencegrid.org/iris-hep/kuantifier
+
+Then [install](https://helm.sh/docs/helm/helm_install/) it:
+
+    helm install kuantifier oci://hub.opensciencegrid.org/iris-hep/kuantifier --version <latest-version> --values my-values.yaml
+
+Or [upgrade] an existing installation with a new helm chart version or set of configuration values:
+
+    helm upgrade kuantifier oci://hub.opensciencegrid.org/iris-hep/kuantifier --version <latest-version> --values my-values.yaml
+
+## Configuration
+
+Helm charts are configured via a yaml [configuration file](https://helm.sh/docs/chart_template_guide/values_files/). The default
+configuration for Kuantifier is found at [values.yaml](./values.yaml). A custom values.yaml may be applied to a chart during
+installation or upgrade via the `--values` or `-f` helm command line option. The parameters of Kuantifier's values.yaml are documented
+below.
+
+### Values.yaml Parameters
+
+#### General Configuration
+* `.Values.outputFormat`: The outlet to report records to. Supports two values:
+  * `"ssmsend"`: Output to APEL via SSMSend.
+  * `"gratia"`: Output to [GRACC](https://gracc.opensciencegrid.org/) via 
+    [Gratia](https://github.com/opensciencegrid/gratia-probe/).
+* `.Values.cronjob`: Configuration for the Kubernetes [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)
+  object that periodically runs Kuantifier.
+  * `.schedule`: Cron expression for scheduling the CronJob
+  * `.priorityClassName`: [Priority Class](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) for the
+    pods that run the kuantifier job.
+  * `.ttlSecondsAfterFinished`: Duration to persist completed pods after completion. 
+* `.Values.pspName`: If specified, a [Pod Security Policy](https://kubernetes.io/docs/concepts/security/pod-security-policy/).
+    name to use. Deprecated in newer versions of Kubernetes.
+* `.Values.runAsNonRoot`: If true, run the pod as a [non-root user](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
+
+* `.Values.dataVolumeSize`: The size of the volume where Kuantifier stores its intermediate results between querying prometheus
+  and outputting to an external service. Note that Gratia output may require a significantly larger data volume size, as it operates
+  on non-summarized records.
+
+* `.Values.processor`: Configuration for the container that queries Prometheus to generate Job metrics records.
+  * `.image_repository`: Docker image repository from which to pull the processor image.
+  * `.image_tag`: Optionally specify an image version.
+  * `.image_pull_policy`: [Image Pull Policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) for the processor container.
+  * `.resources`: [Resource requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for
+   the processor container. Allow approximately 10KB of memory per job record being processed.
+  * `.config`: Environment variables for the processor. See [KAPELConfig.py](../python/KAPELConfig.py) for full details. 
+  Must specify at least the following:
+    * `NAMESPACE`: The namespace in which pilot job containers are run. Kuantifier assumes every pod in the namespace is a pilot job.
+    * `SITE_NAME`: The name of the site being reported on.
+    * `SUBMIT_HOST`: Uniquely identifying name for the cluster.
+    * `VO_NAME`: VO of jobs.
+    * `BENCHMARK_VALUE`: Only required for SSMSend output.
+  * `.prometheus_auth`: If your Prometheus instance is configured to require [Authentication](https://prometheus.io/docs/prometheus/latest/configuration/https/)
+    from within the cluster, specify a Secret containing a value for the Authentication header.
+ 
+#### Gratia Output Configuration
+
+The following values only apply if `.Values.outputFormat` equals `"gratia"`:
+
+* `.Values.gratia`: Configuration for the container that outputs job records to GRACC.
+  * `.image_repository`: Docker image repository from which to pull the Gratia output image.
+  * `.image_tag`: Optionally specify an image version.
+  * `.resources`: Resource requests and limits for the gratia output container.
+  * `.config`: Environment variables for the gratia output container. Currently, it is strongly recommended to use the default.
+
+#### SSMSend Output Configuration
+
+The following values only apply if `.Values.outputFormat` equals `"ssmsend"`:
+
+* `.Values.ssmsend`: Configuration for the container that outputs job records to APEL.
+  * `.image_repository`: Docker image repository from which to pull the ssmsend output image.
+  * `.image_tag`: Optionally specify an image version.
+  * `.resources`: Resource requests and limits for the ssmsend output container.
+  * `.x509cert` and `.x509key`: Base64-encoded public cert and private key to authenticate to APEL.

--- a/chart/README.md
+++ b/chart/README.md
@@ -33,13 +33,13 @@ below.
     [Gratia](https://github.com/opensciencegrid/gratia-probe/).
 * `.Values.cronjob`: Configuration for the Kubernetes [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)
   object that periodically runs Kuantifier.
-  * `.schedule`: Cron expression for scheduling the CronJob
+  * `.schedule`: Cron expression for scheduling the CronJob.
   * `.priorityClassName`: [Priority Class](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) for the
     pods that run the Kuantifier job.
   * `.ttlSecondsAfterFinished`: Duration to persist completed pods after completion. 
-* `.Values.pspName`: If specified, a [Pod Security Policy](https://kubernetes.io/docs/concepts/security/pod-security-policy/).
+* `.Values.pspName`: If specified, a [Pod Security Policy](https://kubernetes.io/docs/concepts/security/pod-security-policy/)
     name to use. Deprecated in newer versions of Kubernetes.
-* `.Values.user`: For newer versions of Kubernetes, set the non-privileged [user id and group id](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+* `.Values.user`: Can be used to change the [user id and group id](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) the pod runs as if needed.
 
 * `.Values.dataVolumeSize`: The size of the volume where Kuantifier stores its intermediate results between querying Prometheus
   and outputting to an external service. Note that Gratia output may require a significantly larger data volume size, as it operates
@@ -53,8 +53,8 @@ below.
    the processor container. Allow approximately 10KB of memory per job record being processed.
   * `.config`: Environment variables for the processor. See [KAPELConfig.py](../python/KAPELConfig.py) for full details. 
   Must specify at least the following:
-    * `NAMESPACE`: The namespace in which pods that execute jobs are run. Kuantifier assumes every pod in the namespace executes jobs.
-    * `SITE_NAME`: The name of the site being reported on.
+    * `NAMESPACE`: The namespace of the pods for which Kuantifier will collect and report metrics.
+    * `SITE_NAME`: The name of the site being reported.
     * `SUBMIT_HOST`: Uniquely identifying name for the cluster.
     * `VO_NAME`: VO of jobs.
     * `BENCHMARK_VALUE`: The value to use for normalizing to CPU performance - for APEL accounting.
@@ -66,7 +66,7 @@ below.
 The following values only apply if `.Values.outputFormat` equals `"gratia"`:
 
 * `.Values.gratia`: Configuration for the container that outputs job records to GRACC.
-  * `.image_repository`: Docker image repository from which to pull the Gratia output image.
+  * `.image_repository`: OCI image repository from which to pull the Gratia output image.
   * `.image_tag`: Optionally specify an image version.
   * `.resources`: Resource requests and limits for the Gratia output container.
   * `.config`: Environment variables for the Gratia output container. Currently, it is strongly recommended to use the default.
@@ -76,7 +76,7 @@ The following values only apply if `.Values.outputFormat` equals `"gratia"`:
 The following values only apply if `.Values.outputFormat` equals `"ssmsend"`:
 
 * `.Values.ssmsend`: Configuration for the container that outputs job records to APEL.
-  * `.image_repository`: Docker image repository from which to pull the SSM output image.
+  * `.image_repository`: OCI image repository from which to pull the SSM output image.
   * `.image_tag`: Optionally specify an image version.
   * `.resources`: Resource requests and limits for the SSM output container.
-  * `.x509cert` and `.x509key`: Base64-encoded public cert and private key to authenticate to APEL.
+  * `.x509cert` and `.x509key`: Base64-encoded public cert and private key for content signing when sending messages with SSM for APEL.

--- a/chart/README.md
+++ b/chart/README.md
@@ -13,7 +13,7 @@ Then [install](https://helm.sh/docs/helm/helm_install/) it:
 
     helm install kuantifier oci://hub.opensciencegrid.org/iris-hep/kuantifier --version <latest-version> --values my-values.yaml
 
-Or [upgrade] an existing installation with a new Helm chart version or set of configuration values:
+Or [upgrade](https://helm.sh/docs/helm/helm_upgrade/) an existing installation with a new helm chart version or set of configuration values:
 
     helm upgrade kuantifier oci://hub.opensciencegrid.org/iris-hep/kuantifier --version <latest-version> --values my-values.yaml
 
@@ -53,7 +53,7 @@ below.
    the processor container. Allow approximately 10KB of memory per job record being processed.
   * `.config`: Environment variables for the processor. See [KAPELConfig.py](../python/KAPELConfig.py) for full details. 
   Must specify at least the following:
-    * `NAMESPACE`: The namespace in which pilot job containers are run. Kuantifier assumes every pod in the namespace is a pilot job.
+    * `NAMESPACE`: The namespace in which pods that execute jobs are run. Kuantifier assumes every pod in the namespace executes jobs.
     * `SITE_NAME`: The name of the site being reported on.
     * `SUBMIT_HOST`: Uniquely identifying name for the cluster.
     * `VO_NAME`: VO of jobs.

--- a/chart/README.md
+++ b/chart/README.md
@@ -46,7 +46,7 @@ below.
   on non-summarized records.
 
 * `.Values.processor`: Configuration for the container that queries Prometheus to generate Job metric records.
-  * `.image_repository`: Docker image repository from which to pull the processor image.
+  * `.image_repository`: OCI image repository from which to pull the processor image.
   * `.image_tag`: Optionally specify an image version.
   * `.image_pull_policy`: [Image Pull Policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) for the processor container.
   * `.resources`: [Resource requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for

--- a/chart/README.md
+++ b/chart/README.md
@@ -39,7 +39,7 @@ below.
   * `.ttlSecondsAfterFinished`: Duration to persist completed pods after completion. 
 * `.Values.pspName`: If specified, a [Pod Security Policy](https://kubernetes.io/docs/concepts/security/pod-security-policy/).
     name to use. Deprecated in newer versions of Kubernetes.
-* `.Values.runAsNonRoot`: If true, run the pod as a [non-root user](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
+* `.Values.user`: For newer versions of Kubernetes, set the non-privileged [user id and group id](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 
 * `.Values.dataVolumeSize`: The size of the volume where Kuantifier stores its intermediate results between querying Prometheus
   and outputting to an external service. Note that Gratia output may require a significantly larger data volume size, as it operates

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -29,7 +29,9 @@ spec:
           # If a container fails, fail the pod (job controller will make a fresh new pod)
           restartPolicy: Never
           securityContext:
-            runAsNonRoot: {{ .Values.runAsNonRoot }}
+            runAsNonRoot: true
+            runAsUser: {{ .Values.serviceUser.uid }}
+            runAsGroup: {{ .Values.serviceUser.gid }}
           volumes:
             {{ if eq .Values.outputFormat "ssmsend" }}
             - name: ssmsend-config-volume

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -48,7 +48,7 @@ spec:
             {{ end }}
             - name: data-volume
               emptyDir:
-                sizeLimit: 1000M
+                sizeLimit: {{ .Values.dataVolumeSize }}
             - name: run-volume
               emptyDir:
                 sizeLimit: 50M

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -28,7 +28,7 @@ spec:
           securityContext:
             runAsNonRoot: true
           volumes:
-            {{ if eq .Values.output-format "ssmsend" }}
+            {{ if eq .Values.output_format "ssmsend" }}
             - name: ssmsend-config-volume
               configMap:
                 name: {{ .Release.Name }}-ssmsend-config
@@ -81,7 +81,7 @@ spec:
                 - name: manual-records
                   mountPath: /srv/manual
           containers:
-          {{ if eq .Values.output-format "gratia" }}
+          {{ if eq .Values.output_format "gratia" }}
             - name: gratia-output
               image: {{ .Values.gratia.image_repository}}:{{ .Values.gratia.image_tag | default .Chart.AppVersion }}
               resources:

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -30,8 +30,10 @@ spec:
           restartPolicy: Never
           securityContext:
             runAsNonRoot: true
+            {{ if .Values.serviceUser.uid }}
             runAsUser: {{ .Values.serviceUser.uid }}
             runAsGroup: {{ .Values.serviceUser.gid }}
+            {{ end }}
           volumes:
             {{ if eq .Values.outputFormat "ssmsend" }}
             - name: ssmsend-config-volume

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -17,6 +17,9 @@ spec:
       ttlSecondsAfterFinished: {{ .Values.cronjob.ttlSecondsAfterFinished }}
       backoffLimit: 2
       template:
+        metadata:
+          labels:
+            app: kapel
         spec:
           {{- if .Values.cronjob.priorityClassName }}
           priorityClassName: {{ .Values.cronjob.priorityClassName }}
@@ -25,8 +28,8 @@ spec:
           activeDeadlineSeconds: 14400
           # If a container fails, fail the pod (job controller will make a fresh new pod)
           restartPolicy: Never
-          securityContext:
-            runAsNonRoot: true
+          # securityContext:
+          #  runAsNonRoot: true
           volumes:
             {{ if eq .Values.output_format "ssmsend" }}
             - name: ssmsend-config-volume
@@ -54,11 +57,9 @@ spec:
                 name: {{ .Release.Name }}-manual-records
           initContainers:
             - name: processor
-              image: library/python:3
+              image: {{ .Values.processor.image_repository }}:{{ .Values.processor.image_tag | default .Chart.AppVersion }}
               resources:
                 {{- toYaml .Values.processor.resources | nindent 16 }}
-              command: ["/bin/bash"]
-              args: ["-c", "mkdir $HOME; git -C $HOME clone -b {{ .Values.processor.deploy_branch }} https://github.com/rptaylor/kapel.git; cd ~/kapel/python; pip install -r requirements.txt; python KAPEL.py"]
               env:
                 # for pip installation
                 - name: HOME

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -63,6 +63,9 @@ spec:
             - name: processor
               image: {{ .Values.processor.image_repository }}:{{ .Values.processor.image_tag | default .Chart.AppVersion }}
               imagePullPolicy: {{ .Values.processor.image_pull_policy }}
+              workingDir: /src
+              command: [ "python3" ]
+              args: [ "KAPEL.py" ]
               resources:
                 {{- toYaml .Values.processor.resources | nindent 16 }}
               env:
@@ -102,6 +105,9 @@ spec:
           {{ if eq .Values.outputFormat "gratia" }}
             - name: gratia-output
               image: {{ .Values.gratia.image_repository}}:{{ .Values.gratia.image_tag | default .Chart.AppVersion }}
+              workingDir: /gratia
+              command: [ "python3" ]
+              args: [ "kubernetes_meter.py" ]
               resources:
                 {{- toYaml .Values.gratia.resources | nindent 16 }}
               envFrom:

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -79,6 +79,13 @@ spec:
                 - name: SUMMARIZE_RECORDS
                   value: "False"
                 {{ end }}
+                {{ if .Values.processor.prometheus_auth.secret }}
+                - name: PROMETHEUS_AUTH_HEADER
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.processor.prometheus_auth.secret }}
+                      key: {{ .Values.processor.prometheus_auth.key }}
+                {{ end }}
               envFrom:
                 - configMapRef:
                     name: {{ .Release.Name }}-processor-config

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -30,9 +30,9 @@ spec:
           restartPolicy: Never
           securityContext:
             runAsNonRoot: true
-            {{ if .Values.serviceUser.uid }}
-            runAsUser: {{ .Values.serviceUser.uid }}
-            runAsGroup: {{ .Values.serviceUser.gid }}
+            {{ if .Values.user.uid }}
+            runAsUser: {{ .Values.user.uid }}
+            runAsGroup: {{ .Values.user.gid }}
             {{ end }}
           volumes:
             {{ if eq .Values.outputFormat "ssmsend" }}

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -28,6 +28,7 @@ spec:
           securityContext:
             runAsNonRoot: true
           volumes:
+            {{ if eq .Values.output-format "ssmsend" }}
             - name: ssmsend-config-volume
               configMap:
                 name: {{ .Release.Name }}-ssmsend-config
@@ -35,6 +36,7 @@ spec:
               secret:
                 secretName: {{ .Release.Name }}-ssmsend-secret
                 defaultMode: 0400
+            {{ end }}
             {{ if .Values.gridSecurityHostPath }}
             - name: grid-security-volume
               hostPath:
@@ -79,6 +81,18 @@ spec:
                 - name: manual-records
                   mountPath: /srv/manual
           containers:
+          {{ if eq .Values.output-format "gratia" }}
+            - name: gratia-output
+              image: {{ .Values.gratia.image_repository}}:{{ .Values.gratia.image_tag | default .Chart.AppVersion }}
+              resources:
+                {{- toYaml .Values.gratia.resources | nindent 16 }}
+              envFrom:
+                - configMapRef:
+                    name: {{ .Release.Name }}-gratia-output-config
+              volumeMounts:
+                - name: apel-data-volume
+                  mountPath: /srv/kapel
+          {{ else }}
             - name: ssmsend
               image: {{ .Values.ssmsend.image_repository }}:{{ .Values.ssmsend.image_tag | default .Chart.AppVersion }}
               resources:
@@ -109,3 +123,4 @@ spec:
                   mountPath: /var/spool/apel/outgoing
                 - name: run-volume
                   mountPath: /var/run/apel
+          {{ end }}

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -58,6 +58,7 @@ spec:
           initContainers:
             - name: processor
               image: {{ .Values.processor.image_repository }}:{{ .Values.processor.image_tag | default .Chart.AppVersion }}
+              imagePullPolicy: {{ .Values.processor.image_pull_policy }}
               resources:
                 {{- toYaml .Values.processor.resources | nindent 16 }}
               env:
@@ -73,6 +74,11 @@ spec:
                 # to see log output immediately
                 - name: PYTHONUNBUFFERED
                   value: "TRUE"
+                {{ if eq .Values.output_format "gratia" }}
+                # Gratia needs individual job records rather than summaries
+                - name: SUMMARIZE_RECORDS
+                  value: "False"
+                {{ end }}
               envFrom:
                 - configMapRef:
                     name: {{ .Release.Name }}-processor-config

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -28,10 +28,10 @@ spec:
           activeDeadlineSeconds: 14400
           # If a container fails, fail the pod (job controller will make a fresh new pod)
           restartPolicy: Never
-          # securityContext:
-          #  runAsNonRoot: true
+          securityContext:
+            runAsNonRoot: {{ .Values.runAsNonRoot }}
           volumes:
-            {{ if eq .Values.output_format "ssmsend" }}
+            {{ if eq .Values.outputFormat "ssmsend" }}
             - name: ssmsend-config-volume
               configMap:
                 name: {{ .Release.Name }}-ssmsend-config
@@ -74,7 +74,7 @@ spec:
                 # to see log output immediately
                 - name: PYTHONUNBUFFERED
                   value: "TRUE"
-                {{ if eq .Values.output_format "gratia" }}
+                {{ if eq .Values.outputFormat "gratia" }}
                 # Gratia needs individual job records rather than summaries
                 - name: SUMMARIZE_RECORDS
                   value: "False"
@@ -95,7 +95,7 @@ spec:
                 - name: manual-records
                   mountPath: /srv/manual
           containers:
-          {{ if eq .Values.output_format "gratia" }}
+          {{ if eq .Values.outputFormat "gratia" }}
             - name: gratia-output
               image: {{ .Values.gratia.image_repository}}:{{ .Values.gratia.image_tag | default .Chart.AppVersion }}
               resources:
@@ -104,7 +104,7 @@ spec:
                 - configMapRef:
                     name: {{ .Release.Name }}-gratia-output-config
               volumeMounts:
-                - name: apel-data-volume
+                - name: data-volume
                   mountPath: /srv/kapel
           {{ else }}
             - name: ssmsend

--- a/chart/templates/gratia-output-config.yaml
+++ b/chart/templates/gratia-output-config.yaml
@@ -1,0 +1,10 @@
+{{ if eq .Values.output-format "gratia" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-gratia-output-config
+  labels:
+    {{- include "kapel.labels" . | nindent 4 }}
+data:
+{{ .Values.gratia.config | indent 2 }}
+{{ end }}

--- a/chart/templates/gratia-output-config.yaml
+++ b/chart/templates/gratia-output-config.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Values.outputFormat "gratia" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,4 @@ metadata:
     {{- include "kapel.labels" . | nindent 4 }}
 data:
 {{ .Values.gratia.config | indent 2 }}
+{{ end }}

--- a/chart/templates/gratia-output-config.yaml
+++ b/chart/templates/gratia-output-config.yaml
@@ -1,4 +1,3 @@
-{{ if eq .Values.output_format "gratia" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,4 +6,3 @@ metadata:
     {{- include "kapel.labels" . | nindent 4 }}
 data:
 {{ .Values.gratia.config | indent 2 }}
-{{ end }}

--- a/chart/templates/gratia-output-config.yaml
+++ b/chart/templates/gratia-output-config.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.output-format "gratia" }}
+{{ if eq .Values.output_format "gratia" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/chart/templates/ssmsend-config.yaml
+++ b/chart/templates/ssmsend-config.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Values.outputFormat "ssmsend" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -34,3 +35,4 @@ data:
     # Available logging levels: DEBUG, INFO, WARN, ERROR, CRITICAL
     level: DEBUG
     console: true
+{{ end }}

--- a/chart/templates/ssmsend-secret.yaml
+++ b/chart/templates/ssmsend-secret.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Values.outputFormat "ssmsend" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,3 +9,4 @@ type: Opaque
 data:
   x509cert.pem: {{ .Values.ssmsend.x509cert }}
   x509key.pem: {{ .Values.ssmsend.x509key }}
+{{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -17,6 +17,7 @@ output_format: ssmsend
 processor:
   image_repository: "hub.opensciencegrid.org/osgpreview/kapel-processor"
   image_tag: "latest"
+  image_pull_policy: "IfNotPresent"
   resources:
     # very generous estimate: approx 10 KiB memory per job record
     limits:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,8 +15,10 @@ gridSecurityHostPath: true
 # Other than that no special privileges are required so a default PSP should be sufficient.
 pspName: ""
 
-# Corresponds to securityContext.runAsNonRoot
-runAsNonRoot: true
+# UID and GID for the pod service user
+serviceUser:
+  uid: 10000
+  gid: 10000
 
 # Size of the data volume in which to store intermediate APEL records. outputFormat "gratia"
 # outputs individual records rather than summaries, and may require a larger data volume size.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -68,11 +68,11 @@ gratia:
   # Optionally overwrite container version. Default is chart appVersion.
   image_tag: "latest"
   config: |
-    GRATIA_CONFIG_PATH=/etc/kapel-gratia-output/gratia-config
-    GRATIA_REPORTER=osgpilot_meter
-    GRATIA_SERVICE=OSGPilotContainer
-    GRATIA_PROBE_MANAGER=condor
-    GRATIA_PROBE_VERSION=2.8.4-1.osg.el8.b2e780f
+    GRATIA_CONFIG_PATH: "/etc/kapel-gratia-output/gratia-config"
+    GRATIA_REPORTER: "osgpilot_meter"
+    GRATIA_SERVICE: "OSGPilotContainer"
+    GRATIA_PROBE_MANAGER: "condor"
+    GRATIA_PROBE_VERSION: "2.8.4-1.osg.el8.b2e780f"
 
 
 nameOverride: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -36,6 +36,10 @@ processor:
     #VO_NAME: "atlas"
   # name of git branch to use
   deploy_branch: "prod"
+  # Authentication secret for Prometheus, if any
+  prometheus_auth:
+    secret: null
+    key: null
 
 
 ssmsend:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -11,8 +11,11 @@ gridSecurityHostPath: true
 # Other than that no special privileges are required so a default PSP should be sufficient.
 pspName: ""
 
+# Corresponds to securityContext.runAsNonRoot
+runAsNonRoot: true
+
 # "ssmsend" or "gratia"
-output_format: ssmsend
+outputFormat: ssmsend
 
 processor:
   image_repository: "hub.opensciencegrid.org/osgpreview/kapel-processor"
@@ -79,7 +82,6 @@ gratia:
     GRATIA_REPORTER: "osgpilot_meter"
     GRATIA_SERVICE: "OSGPilotContainer"
     GRATIA_PROBE_MANAGER: "condor"
-    GRATIA_PROBE_VERSION: "2.8.4-1.osg.el8.b2e780f"
 
 
 nameOverride: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -16,7 +16,7 @@ gridSecurityHostPath: true
 pspName: ""
 
 # UID and GID for the pod service user
-serviceUser:
+user:
   uid: 10000
   gid: 10000
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -26,7 +26,8 @@ dataVolumeSize: 1000M
 
 processor:
   image_repository: "hub.opensciencegrid.org/osgpreview/kapel-processor"
-  image_tag: "latest"
+  # Optionally overwrite container version. Default is chart appVersion.
+  image_tag: ""
   image_pull_policy: "IfNotPresent"
   resources:
     # very generous estimate: approx 10 KiB memory per job record
@@ -82,7 +83,7 @@ gratia:
   # Location of gratia output container.
   image_repository: "hub.opensciencegrid.org/osgpreview/kapel-gratia-output"
   # Optionally overwrite container version. Default is chart appVersion.
-  image_tag: "latest"
+  image_tag: ""
   # Config options for Gratia. At present, only GRATIA_CONFIG_PATH can be specified,
   # And points to the default Gratia config file.
   config: |

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -71,7 +71,7 @@ gratia:
   # Optionally overwrite container version. Default is chart appVersion.
   image_tag: "latest"
   config: |
-    GRATIA_CONFIG_PATH: "/etc/kapel-gratia-output/gratia-config"
+    GRATIA_CONFIG_PATH: "/etc/gratia/kubernetes/ProbeConfig"
     GRATIA_REPORTER: "osgpilot_meter"
     GRATIA_SERVICE: "OSGPilotContainer"
     GRATIA_PROBE_MANAGER: "condor"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3,6 +3,10 @@ cronjob:
   priorityClassName: ""
   ttlSecondsAfterFinished: 7776000
 
+# "ssmsend" or "gratia"
+outputFormat: ssmsend
+
+
 # If true, /cvmfs/grid.cern.ch/etc/grid-security/certificates/ will be mounted as a hostPath volume.
 # If false, you will need to set up an alternative way of providing the ca-policy-* packages and CRLs in the ssmsend container.
 gridSecurityHostPath: true
@@ -14,8 +18,9 @@ pspName: ""
 # Corresponds to securityContext.runAsNonRoot
 runAsNonRoot: true
 
-# "ssmsend" or "gratia"
-outputFormat: ssmsend
+# Size of the data volume in which to store intermediate APEL records. outputFormat "gratia"
+# outputs individual records rather than summaries, and may require a larger data volume size.
+dataVolumeSize: 1000M
 
 processor:
   image_repository: "hub.opensciencegrid.org/osgpreview/kapel-processor"
@@ -37,8 +42,7 @@ processor:
     #BENCHMARK_VALUE: "15.0"
     #NAMESPACE: "harvester"
     #VO_NAME: "atlas"
-  # name of git branch to use
-  deploy_branch: "prod"
+
   # Authentication secret for Prometheus, if any
   prometheus_auth:
     secret: null
@@ -77,11 +81,10 @@ gratia:
   image_repository: "hub.opensciencegrid.org/osgpreview/kapel-gratia-output"
   # Optionally overwrite container version. Default is chart appVersion.
   image_tag: "latest"
+  # Config options for Gratia. At present, only GRATIA_CONFIG_PATH can be specified,
+  # And points to the default Gratia config file.
   config: |
     GRATIA_CONFIG_PATH: "/etc/gratia/kubernetes/ProbeConfig"
-    GRATIA_REPORTER: "osgpilot_meter"
-    GRATIA_SERVICE: "OSGPilotContainer"
-    GRATIA_PROBE_MANAGER: "condor"
 
 
 nameOverride: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,7 +12,7 @@ gridSecurityHostPath: true
 pspName: ""
 
 # "ssmsend" or "gratia"
-output-format: ssmsend
+output_format: ssmsend
 
 processor:
   resources:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -11,6 +11,9 @@ gridSecurityHostPath: true
 # Other than that no special privileges are required so a default PSP should be sufficient.
 pspName: ""
 
+# "ssmsend" or "gratia"
+output-format: ssmsend
+
 processor:
   resources:
     # very generous estimate: approx 10 KiB memory per job record
@@ -31,6 +34,7 @@ processor:
   # name of git branch to use
   deploy_branch: "prod"
 
+
 ssmsend:
   resources:
     limits:
@@ -50,6 +54,26 @@ ssmsend:
   # Using a base64 encoded string with no line breaks avoids issues of indentation and double YAML encoding if Ansible is used for Helm.
   x509cert: aW5zZXJ0IGJhc2U2NC1lbmNvZGVkIHN0cmluZyBvZiB0aGUgWDUwOSBwdWJsaWMgY2VydCBmb3IgQVBFTCBwdWJsaXNoZXIK
   x509key: aW5zZXJ0IGJhc2U2NC1lbmNvZGVkIHN0cmluZyBvZiB0aGUgWDUwOSBwcml2YXRlIGtleSBmb3IgQVBFTCBwdWJsaXNoZXIK
+
+gratia:
+  resources:
+    limits:
+      cpu: "0.5"
+      memory: "500Mi"
+    requests:
+      cpu: "0.1"
+      memory: "50Mi"
+  # Location of gratia output container.
+  image_repository: "hub.opensciencegrid.org/mwestphall/kapel-gratia-output"
+  # Optionally overwrite container version. Default is chart appVersion.
+  image_tag: "latest"
+  config: |
+    GRATIA_CONFIG_PATH=/etc/kapel-gratia-output/gratia-config
+    GRATIA_REPORTER=osgpilot_meter
+    GRATIA_SERVICE=OSGPilotContainer
+    GRATIA_PROBE_MANAGER=condor
+    GRATIA_PROBE_VERSION=2.8.4-1.osg.el8.b2e780f
+
 
 nameOverride: ""
 fullnameOverride: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,6 +15,8 @@ pspName: ""
 output_format: ssmsend
 
 processor:
+  image_repository: "hub.opensciencegrid.org/osgpreview/kapel-processor"
+  image_tag: "latest"
   resources:
     # very generous estimate: approx 10 KiB memory per job record
     limits:
@@ -64,7 +66,7 @@ gratia:
       cpu: "0.1"
       memory: "50Mi"
   # Location of gratia output container.
-  image_repository: "hub.opensciencegrid.org/mwestphall/kapel-gratia-output"
+  image_repository: "hub.opensciencegrid.org/osgpreview/kapel-gratia-output"
   # Optionally overwrite container version. Default is chart appVersion.
   image_tag: "latest"
   config: |


### PR DESCRIPTION
- Update values.yaml with configuration options for a Gratia output container
- Update cronjob.yaml to optionally run the Gratia output container rather than the APEL output container
- Update cronjob.yaml to run the processor initContainer via a custom docker image rather than by pulling the repo

The Docker images that are run for both the processor initContainer and the Gratia output container are currently being manually built and pushed into OSG Harbor. We will need to design a CI workflow before these changes to the helm chart can be used in production.