### PR TITLE
remove assertion about list lengths

### DIFF
--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -195,15 +195,11 @@ def record_summarized_period(config, period_start, year, month, results):
     starttime = results['starttime']
     cores = results['cores']
     result_lengths = list((len(l) for l in results.values()))
-    # Confirm the assumption that cputime should have the fewest entries, while starttime and cores may have additional ones
-    # corresponding to jobs that have started but not finished yet, and endtime may have additional ones if there are pods without CPU resource requests.
-    # We only want the jobs for which all values are available: start time, end time, CPU request.
     # Note that jobs which started last month and finished this month will be properly included and accounted in this month.
-    assert len(cputime) == min(result_lengths), "cputime should be the shortest list"
     # However, jobs that finished last month may show up in this month's data if they are still present on the cluster this month (in Completed state).
     # Exclude them by filtering with a lambda (since you can't pass an argument to a function object AFAIK).
     endtime = dict(filter(lambda x: x[1] >= datetime.datetime.timestamp(period_start), endtime.items()))
-    # Prepare to iterate over jobs which meet all criteria.
+    # Prepare to iterate over jobs which meet all criteria: the cputime result exists, so there must be a valid start and end time, and core count.
     valid_jobs = cputime.keys() & endtime.keys()
     # avoid sending empty records
     if len(valid_jobs) == 0:

--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -194,7 +194,6 @@ def record_summarized_period(config, period_start, year, month, results):
     endtime = results['endtime']
     starttime = results['starttime']
     cores = results['cores']
-    result_lengths = list((len(l) for l in results.values()))
     # Note that jobs which started last month and finished this month will be properly included and accounted in this month.
     # However, jobs that finished last month may show up in this month's data if they are still present on the cluster this month (in Completed state).
     # Exclude them by filtering with a lambda (since you can't pass an argument to a function object AFAIK).


### PR DESCRIPTION
This assumption about list lengths was useful during validation, but with the recent addition of memory and CPU usage metrics, the cputime query is no longer the all encompassing metric which depends on and guarantees the presence of all other metrics for a given pod (since cputime is a function of start time, end time, and CPU request).
In principle the memory metrics or CPU usage could be (and in fact are, based on the error below) missing for some pods. 

This avoids the following error:
```
Processing year 2024, month 6, querying from 2024-07-01T00:00:00+00:00 and going back 2592000 s to 2024-06-01T00:00:00+00:00.
Executing cputime query: (max_over_time(kube_pod_completion_time{namespace="harvester"}[2592000s]) - max_over_time(kube_pod_start_time{namespace="harvester"}[2592000s])) * on (pod) group_left() max without (instance, node) (max_over_time(kube_pod_container_resource_requests{resource="cpu", node != "", namespace="harvester"}[2592000s]))
Query finished in 5.042580407112837 s, processed in 0.04322641482576728 s. Got 51692 items from 51692 results. Peak RAM usage: 176664K.
Executing endtime query: max_over_time(kube_pod_completion_time{namespace="harvester"}[2592000s])
Query finished in 1.884917760733515 s, processed in 0.038964908104389906 s. Got 51692 items from 51692 results. Peak RAM usage: 257224K.
Executing starttime query: max_over_time(kube_pod_start_time{namespace="harvester"}[2592000s])
Query finished in 1.6605819943360984 s, processed in 0.04218143178150058 s. Got 51695 items from 51695 results. Peak RAM usage: 264740K.
Executing cores query: max_over_time(kube_pod_container_resource_requests{resource="cpu", node != "", namespace="harvester"}[2592000s])
Query finished in 2.0840396899729967 s, processed in 0.05104288784787059 s. Got 51695 items from 51695 results. Peak RAM usage: 296804K.
Executing memory query: sum by (pod) (max_over_time(kube_pod_container_resource_requests{resource="memory", node!="", namespace="harvester"}[2592000s])) / 1000
Query finished in 1.6492273383773863 s, processed in 0.03538353182375431 s. Got 51695 items from 51695 results. Peak RAM usage: 296804K.
Executing cpuusage query: sum by (pod) (last_over_time(container_cpu_usage_seconds_total{namespace="harvester"}[2592000s]))
Query finished in 2.5884828618727624 s, processed in 0.043710787780582905 s. Got 51512 items from 51512 results. Peak RAM usage: 296804K.
Traceback (most recent call last):
  File "/tmp/home/kapel/python/KAPEL.py", line 368, in <module>
    main(args.env_file)
  File "/tmp/home/kapel/python/KAPEL.py", line 361, in main
    process_period(config=cfg, period=p)
  File "/tmp/home/kapel/python/KAPEL.py", line 327, in process_period
    record_summarized_period(config, period_start, period['year'], period['month'], results)
  File "/tmp/home/kapel/python/KAPEL.py", line 202, in record_summarized_period
    assert len(cputime) == min(result_lengths), "cputime should be the shortest list"
AssertionError: cputime should be the shortest list
```

There are 51692 cputime results, but only 51512 cpuusage results.  I think this makes sense because the latter come from CAdvisor/cgroup-based metrics on kubelets, rather than KSM. There could be e.g. kubelet responsiveness issues or other problems affecting collection of CPU usage but not the other metrics, because they come from a different source.