### PR TITLE
Make benchmark value optional

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/README.md
+++ b/chart/README.md
@@ -57,7 +57,7 @@ below.
     * `SITE_NAME`: The name of the site being reported.
     * `SUBMIT_HOST`: Uniquely identifying name for the cluster.
     * `VO_NAME`: VO of jobs.
-    * `BENCHMARK_VALUE`: The value to use for normalizing to CPU performance. Required for APEL accounting.
+    * `BENCHMARK_VALUE`: The value to use for normalizing by CPU performance. Required for APEL accounting.
   * `.prometheus_auth`: If your Prometheus instance is configured to require [Authentication](https://prometheus.io/docs/prometheus/latest/configuration/https/)
     from within the cluster, specify a Secret containing a value for the authentication header.
  

--- a/chart/README.md
+++ b/chart/README.md
@@ -57,7 +57,7 @@ below.
     * `SITE_NAME`: The name of the site being reported.
     * `SUBMIT_HOST`: Uniquely identifying name for the cluster.
     * `VO_NAME`: VO of jobs.
-    * `BENCHMARK_VALUE`: The value to use for normalizing to CPU performance - for APEL accounting.
+    * `BENCHMARK_VALUE`: The value to use for normalizing to CPU performance. Required for APEL accounting.
   * `.prometheus_auth`: If your Prometheus instance is configured to require [Authentication](https://prometheus.io/docs/prometheus/latest/configuration/https/)
     from within the cluster, specify a Secret containing a value for the authentication header.
  

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -38,7 +38,6 @@ processor:
       cpu: "0.5"
       memory: "500Mi"
   # See KAPELConfig.py for full details on required configuration.
-  # Along with SITE_NAME and SUBMIT_HOST, you will also need to define BENCHMARK_VALUE, NAMESPACE, and VO_NAME.
   config: |
     SITE_NAME: "EXAMPLE-T2"
     SUBMIT_HOST: "k8s.example.org:6443/namespace"

--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -87,7 +87,7 @@ def summary_message(config, year, month, wall_time, cpu_time, n_jobs, first_end,
     return output
 
 def individual_message(config, pod_name, memory, cores, wall_time, cpu_time, start_time, end_time):
-    """ Write an APEL individual job message based on prometheus metrics from a single pod """
+    """ Write an APEL individual job message based on prometheus metrics from a single pod, without benchmark values. """
     output = (
         f'APEL-individual-job-message: v0.3\n'
         f'Site: {config.site_name}\n'
@@ -96,8 +96,6 @@ def individual_message(config, pod_name, memory, cores, wall_time, cpu_time, sta
         f'MachineName: {pod_name}\n'
         f'LocalJobId: {pod_name}\n'
         f'InfrastructureType: {config.infrastructure_type}\n'
-        f'ServiceLevelType: si2k\n'
-        f'ServiceLevel: {config.benchmark_value * 250}\n'
         f'WallDuration: {wall_time}\n'
         f'CpuDuration: {cpu_time}\n'
         f'MemoryVirtual: {memory}\n'

--- a/python/KAPELConfig.py
+++ b/python/KAPELConfig.py
@@ -1,6 +1,7 @@
 # Configuration module for KAPEL
 
 from environs import Env
+from environs import EnvError
 
 # Read config settings from environment variables (and a named env file in CWD if specified),
 # do input validation, and return a config object. Note, if a '.env' file exists in CWD it will be used by default.
@@ -61,7 +62,10 @@ class KAPELConfig:
         #self.benchmark_type = env.str("BENCHMARK_TYPE", "HEPSPEC")
 
         # Benchmark value
-        self.benchmark_value = env.float("BENCHMARK_VALUE")
+        try:
+            self.benchmark_value = env.float("BENCHMARK_VALUE")
+        except EnvError:
+            pass
 
         # VO of jobs
         self.vo_name = env.str("VO_NAME")


### PR DESCRIPTION
If BENCHMARK_VALUE is not defined, KapelConfig.py will handle the exception.

It will only be referenced by summary records for APEL mode, so in APEL/ssmsend mode if BENCHMARK_VALUE is not defined it will crash after querying instead of during startup.