### PR TITLE
use chart version instead of appVersion for processor image tag

### DIFF
--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -61,7 +61,7 @@ spec:
                 name: {{ .Release.Name }}-manual-records
           initContainers:
             - name: processor
-              image: {{ .Values.processor.image_repository }}:{{ .Values.processor.image_tag | default .Chart.AppVersion }}
+              image: {{ .Values.processor.image_repository }}:{{ .Values.processor.image_tag | default .Chart.Version }}
               imagePullPolicy: {{ .Values.processor.image_pull_policy }}
               workingDir: /src
               command: [ "python3" ]


### PR DESCRIPTION
This way the tags of the processor and ssmsend/gratia containers can be controlled separately.

This will result in using a new hub.opensciencegrid.org/osgpreview/kapel-processor:0.3.0 image that is the same as the previous version hub.opensciencegrid.org/osgpreview/kapel-processor:3.3.1 but with the fix https://github.com/rptaylor/kapel/pull/57 applied.