### PR TITLE
add fsGroup to pod SecurityContext

### DIFF
--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -32,7 +32,10 @@ spec:
             runAsNonRoot: true
             {{ if .Values.user.uid }}
             runAsUser: {{ .Values.user.uid }}
+            {{ end }}
+            {{ if .Values.user.gid }}
             runAsGroup: {{ .Values.user.gid }}
+            fsGroup: {{ .Values.user.gid }}
             {{ end }}
           volumes:
             {{ if eq .Values.outputFormat "ssmsend" }}


### PR DESCRIPTION
So that the ssmsend credential secret will be readable with mode 0400.

Also use a separate condition for uid and gid.