### PR TITLE
make configurable container securityContext

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/README.md
+++ b/chart/README.md
@@ -40,11 +40,10 @@ below.
 * `.Values.pspName`: If specified, a [Pod Security Policy](https://kubernetes.io/docs/concepts/security/pod-security-policy/)
     name to use. Deprecated in newer versions of Kubernetes.
 * `.Values.user`: Can be used to change the [user id and group id](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) the pod runs as if needed.
-
+* `.Values.containerSecurityContext`: For configuring the securityContext of containers.
 * `.Values.dataVolumeSize`: The size of the volume where Kuantifier stores its intermediate results between querying Prometheus
   and outputting to an external service. Note that Gratia output may require a significantly larger data volume size, as it operates
   on non-summarized records.
-
 * `.Values.processor`: Configuration for the container that queries Prometheus to generate Job metric records.
   * `.image_repository`: OCI image repository from which to pull the processor image.
   * `.image_tag`: Optionally specify an image version.

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -69,6 +69,10 @@ spec:
               workingDir: /src
               command: [ "python3" ]
               args: [ "KAPEL.py" ]
+              {{- if .Values.containerSecurityContext }}
+              securityContext:
+                {{- toYaml .Values.containerSecurityContext | nindent 16 }}
+              {{- end }}
               resources:
                 {{- toYaml .Values.processor.resources | nindent 16 }}
               env:
@@ -130,6 +134,10 @@ spec:
               {{ else }}
               args: ["-c", "mkdir $HOME; echo 'ssmsend disabled'; sleep 3600"]
               {{ end }}
+              {{- if .Values.containerSecurityContext }}
+              securityContext:
+                {{- toYaml .Values.containerSecurityContext | nindent 16 }}
+              {{- end }}
               env:
                 # for openssl ~/.rnd
                 - name: HOME

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -24,6 +24,14 @@ user:
 # outputs individual records rather than summaries, and may require a larger data volume size.
 dataVolumeSize: 1000M
 
+# container-level securityContext
+containerSecurityContext:
+  privileged: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
 processor:
   image_repository: "hub.opensciencegrid.org/osgpreview/kapel-processor"
   # Optionally overwrite container version. Default is chart appVersion.
@@ -49,7 +57,6 @@ processor:
   prometheus_auth:
     secret: null
     key: null
-
 
 ssmsend:
   resources:


### PR DESCRIPTION
It is best to make the security level explicit (especially when using Kyverno).

ssmsend and processor are completely unprivileged.


@mwestphall if the same is true for Gratia the same container security context could be applied there too.