### PR TITLE
Add Explicit fields for config entries in values.yaml

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/README.md
+++ b/chart/README.md
@@ -52,14 +52,16 @@ below.
   * `.resources`: [Resource requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for
    the processor container. Allow approximately 10KB of memory per job record being processed.
   * `.config`: Environment variables for the processor. See [KAPELConfig.py](../python/KAPELConfig.py) for full details. 
-  Must specify at least the following:
-    * `NAMESPACE`: The namespace of the pods for which Kuantifier will collect and report metrics.
-    * `SITE_NAME`: The name of the site being reported.
-    * `SUBMIT_HOST`: Uniquely identifying name for the cluster.
-    * `VO_NAME`: VO of jobs.
-    * `BENCHMARK_VALUE`: The value to use for normalizing by CPU performance. Required for APEL accounting.
-  * `.prometheus_auth`: If your Prometheus instance is configured to require [Authentication](https://prometheus.io/docs/prometheus/latest/configuration/https/)
-    from within the cluster, specify a Secret containing a value for the authentication header.
+  Must specify at least the following sub-fields:
+    * `.namespace`: The namespace of the pods for which Kuantifier will collect and report metrics.
+    * `.siteName`: The name of the site being reported.
+    * `.submitHost`: Uniquely identifying name for the cluster.
+    * `.voName`: VO of jobs.
+  * `.prometheus`: Config for connecting to your cluster's Prometheus instance. Has the following sub-fields:
+    * `.server`: Required. URL of your cluster's prometheus server.
+    * `.auth.secret`: Optional. If your Prometheus instance is configured to require [Authentication](https://prometheus.io/docs/prometheus/latest/configuration/https/) from within the cluster, 
+    specify a Secret containing a value for the authentication header.
+    * `.auth.key`: Optional. If using a secret for authentication, which key within the secret to use as the auth header.
  
 #### Gratia Output Configuration
 
@@ -80,3 +82,7 @@ The following values only apply if `.Values.outputFormat` equals `"ssmsend"`:
   * `.image_tag`: Optionally specify an image version.
   * `.resources`: Resource requests and limits for the SSM output container.
   * `.x509cert` and `.x509key`: Base64-encoded public cert and private key for content signing when sending messages with SSM for APEL.
+  * `.config`: Environment variables for the processor that determine ssmsend-specific behavior. Sub-fields include:
+    * `.benchmarkValue`: Required: The value to use for normalizing by CPU performance.
+    * `.nodeCount`: Optional: Number of nodes the report summarizes over.
+    * `.processors`: Optional: Number of processors the report summarizes over.

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -89,12 +89,12 @@ spec:
                 - name: SUMMARIZE_RECORDS
                   value: "False"
                 {{ end }}
-                {{ if .Values.processor.prometheus_auth.secret }}
+                {{ if .Values.processor.prometheus.auth.secret }}
                 - name: PROMETHEUS_AUTH_HEADER
                   valueFrom:
                     secretKeyRef:
-                      name: {{ .Values.processor.prometheus_auth.secret }}
-                      key: {{ .Values.processor.prometheus_auth.key }}
+                      name: {{ .Values.processor.prometheus.auth.secret }}
+                      key: {{ .Values.processor.prometheus.auth.key }}
                 {{ end }}
               envFrom:
                 - configMapRef:

--- a/chart/templates/gratia-output-config.yaml
+++ b/chart/templates/gratia-output-config.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "kapel.labels" . | nindent 4 }}
 data:
-{{ .Values.gratia.config | indent 2 }}
+  GRATIA_CONFIG_PATH: {{ .Values.gratia.config.gratiaConfigPath }}
 {{ end }}

--- a/chart/templates/gratia-output-config.yaml
+++ b/chart/templates/gratia-output-config.yaml
@@ -6,5 +6,10 @@ metadata:
   labels:
     {{- include "kapel.labels" . | nindent 4 }}
 data:
+{{ if kindIs "string" .Values.gratia.config }}
+# Deprecated: Specify the whole ConfigMap as a multiline string
+{{ .Values.processor.config | indent 2 }}
+{{ else }}
   GRATIA_CONFIG_PATH: {{ .Values.gratia.config.gratiaConfigPath }}
+{{ end }}
 {{ end }}

--- a/chart/templates/processor-config.yaml
+++ b/chart/templates/processor-config.yaml
@@ -5,4 +5,28 @@ metadata:
   labels:
     {{- include "kapel.labels" . | nindent 4 }}
 data:
+{{ if .Values.processor.config }}
+# Deprecated: Specify the whole ConfigMap as a multiline string
 {{ .Values.processor.config | indent 2 }}
+{{ else }}
+  SITE_NAME: {{ .Values.processor.clusterConfig.siteName }}
+  SUBMIT_HOST : {{ .Values.processor.clusterConfig.submitHost }}
+  NAMESPACE: {{ .Values.processor.clusterConfig.namespace }}
+  VO_NAME: {{ .Values.processor.clusterConfig.voName }}
+  INFRASTRUCTURE_TYPE: {{ .Values.processor.clusterConfig.infrastructureType }}
+  OUTPUT_PATH: {{ .Values.processor.clusterConfig.outputPath }}
+
+  PROMETHEUS_SERVER: {{ .Values.processor.prometheus.server }}
+
+  PUBLISHING_MODE: {{ .Values.processor.query.mode }}
+  QUERY_TIMEOUT: {{ .Values.processor.query.timeout }}
+  {{ if eq .Values.processor.query.mode "gap"}}
+  QUERY_START: {{ .Values.processor.query.startDate }}
+  QUERY_END: {{ .Values.processor.query.endDate }}
+  {{ end }}
+  {{ if eq .Values.outputFormat "ssmsend"}}
+  BENCHMARK_VALUE: {{ .Values.ssmsend.config.benchmarkValue }}
+  PROCESSORS: {{ .Values.ssmsend.config.processors }}
+  NODECOUNT: {{ .Values.ssmsend.config.nodeCount }}
+  {{ end }}
+{{ end }}

--- a/chart/templates/processor-config.yaml
+++ b/chart/templates/processor-config.yaml
@@ -5,16 +5,16 @@ metadata:
   labels:
     {{- include "kapel.labels" . | nindent 4 }}
 data:
-{{ if .Values.processor.config }}
+{{ if kindIs "string" .Values.processor.config }}
 # Deprecated: Specify the whole ConfigMap as a multiline string
 {{ .Values.processor.config | indent 2 }}
 {{ else }}
-  SITE_NAME: {{ .Values.processor.clusterConfig.siteName }}
-  SUBMIT_HOST : {{ .Values.processor.clusterConfig.submitHost }}
-  NAMESPACE: {{ .Values.processor.clusterConfig.namespace }}
-  VO_NAME: {{ .Values.processor.clusterConfig.voName }}
-  INFRASTRUCTURE_TYPE: {{ .Values.processor.clusterConfig.infrastructureType }}
-  OUTPUT_PATH: {{ .Values.processor.clusterConfig.outputPath }}
+  SITE_NAME: {{ .Values.processor.config.siteName }}
+  SUBMIT_HOST : {{ .Values.processor.config.submitHost }}
+  NAMESPACE: {{ .Values.processor.config.namespace }}
+  VO_NAME: {{ .Values.processor.config.voName }}
+  INFRASTRUCTURE_TYPE: {{ .Values.processor.config.infrastructureType }}
+  OUTPUT_PATH: {{ .Values.processor.config.outputPath }}
 
   PROMETHEUS_SERVER: {{ .Values.processor.prometheus.server }}
 
@@ -25,8 +25,8 @@ data:
   QUERY_END: {{ .Values.processor.query.endDate }}
   {{ end }}
   {{ if eq .Values.outputFormat "ssmsend"}}
-  BENCHMARK_VALUE: {{ .Values.ssmsend.config.benchmarkValue }}
-  PROCESSORS: {{ .Values.ssmsend.config.processors }}
-  NODECOUNT: {{ .Values.ssmsend.config.nodeCount }}
+  BENCHMARK_VALUE: {{ .Values.ssmsend.config.benchmarkValue  | quote }}
+  PROCESSORS: {{ .Values.ssmsend.config.processors | quote  }}
+  NODECOUNT: {{ .Values.ssmsend.config.nodeCount | quote }}
   {{ end }}
 {{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -39,8 +39,6 @@ processor:
       memory: "500Mi"
 
   config:
-    ## Info for APEL records, see https://wiki.egi.eu/wiki/APEL/MessageFormat
-
     # The name of the site being reported.
     siteName: "EXAMPLE-T2"
     # Uniquely identifying name for the cluster.
@@ -49,6 +47,7 @@ processor:
     namespace: "harvester"
     # VO of Jobs
     voName: "atlas"
+    # Infrastructure Type
     infrastructureType: "grid"
     # Output path for intermediate APEL records
     outputPath: /srv/kapel
@@ -62,11 +61,15 @@ processor:
       secret: null
       key: null
 
-  # Configuration for 
+  # Configuration for the prometheus query used to generate reports
   query:
+    # "Auto" to report on the most recent month of data, "gap" to report on a specific time interval
     mode: "auto"
+    # Exit with an error if the query does not complete within the timeout
     timeout: "1800s"
+    # Start date for gap reporting
     startDate: null
+    # End date for gap reporting
     endDate: null
 
 
@@ -90,9 +93,13 @@ ssmsend:
   x509cert: aW5zZXJ0IGJhc2U2NC1lbmNvZGVkIHN0cmluZyBvZiB0aGUgWDUwOSBwdWJsaWMgY2VydCBmb3IgQVBFTCBwdWJsaXNoZXIK
   x509key: aW5zZXJ0IGJhc2U2NC1lbmNvZGVkIHN0cmluZyBvZiB0aGUgWDUwOSBwcml2YXRlIGtleSBmb3IgQVBFTCBwdWJsaXNoZXIK
 
+  # Environment variables for the processor that determine ssmsend-specific behavior. 
   config:
+    # The value to use for normalizing by CPU performance.
     benchmarkValue: "15.0"
+    # Number of nodes the report summarizes over.
     nodeCount: "0"
+    # Number of processors the report summarizes over.
     processors: "0"
 
 gratia:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -37,18 +37,31 @@ processor:
     requests:
       cpu: "0.5"
       memory: "500Mi"
-  # See KAPELConfig.py for full details on required configuration.
-  config: |
-    SITE_NAME: "EXAMPLE-T2"
-    SUBMIT_HOST: "k8s.example.org:6443/namespace"
-    #BENCHMARK_VALUE: "15.0"
-    #NAMESPACE: "harvester"
-    #VO_NAME: "atlas"
 
-  # Authentication secret for Prometheus, if any
-  prometheus_auth:
-    secret: null
-    key: null
+  config: null
+  clusterConfig:
+    ## Info for APEL records, see https://wiki.egi.eu/wiki/APEL/MessageFormat
+    siteName: "EXAMPLE-T2"
+    submitHost: "k8s.example.org:6443/namespace"
+    namespace: "harvester"
+    voName: "atlas"
+    infrastructureType: "grid"
+    outputPath: /srv/kapel
+
+  # Prometheus configuration and authentication
+  prometheus:
+    # URL of the Prometheus server. Default value works within cluster for default bitnami/kube-prometheus Helm release.
+    server: http://kube-prometheus-prometheus.kube-prometheus:9090
+    auth:
+      secret: null
+      key: null
+
+  # Configuration for 
+  query:
+    mode: "auto"
+    timeout: "1800s"
+    startDate: null
+    endDate: null
 
 
 ssmsend:
@@ -71,6 +84,11 @@ ssmsend:
   x509cert: aW5zZXJ0IGJhc2U2NC1lbmNvZGVkIHN0cmluZyBvZiB0aGUgWDUwOSBwdWJsaWMgY2VydCBmb3IgQVBFTCBwdWJsaXNoZXIK
   x509key: aW5zZXJ0IGJhc2U2NC1lbmNvZGVkIHN0cmluZyBvZiB0aGUgWDUwOSBwcml2YXRlIGtleSBmb3IgQVBFTCBwdWJsaXNoZXIK
 
+  config:
+    benchmarkValue: "15.0"
+    nodeCount: 0
+    processors: 0
+
 gratia:
   resources:
     limits:
@@ -83,10 +101,10 @@ gratia:
   image_repository: "hub.opensciencegrid.org/osgpreview/kapel-gratia-output"
   # Optionally overwrite container version. Default is chart appVersion.
   image_tag: ""
-  # Config options for Gratia. At present, only GRATIA_CONFIG_PATH can be specified,
+  # Config options for Gratia. At present, only gratiaConfigPath can be specified,
   # And points to the default Gratia config file.
-  config: |
-    GRATIA_CONFIG_PATH: "/etc/gratia/kubernetes/ProbeConfig"
+  config:
+    gratiaConfigPath: "/etc/gratia/kubernetes/ProbeConfig"
 
 
 nameOverride: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -38,20 +38,26 @@ processor:
       cpu: "0.5"
       memory: "500Mi"
 
-  config: null
-  clusterConfig:
+  config:
     ## Info for APEL records, see https://wiki.egi.eu/wiki/APEL/MessageFormat
+
+    # The name of the site being reported.
     siteName: "EXAMPLE-T2"
+    # Uniquely identifying name for the cluster.
     submitHost: "k8s.example.org:6443/namespace"
+    # Namespace of the pods for which Kuantifier will collect and report metrics.
     namespace: "harvester"
+    # VO of Jobs
     voName: "atlas"
     infrastructureType: "grid"
+    # Output path for intermediate APEL records
     outputPath: /srv/kapel
 
   # Prometheus configuration and authentication
   prometheus:
     # URL of the Prometheus server. Default value works within cluster for default bitnami/kube-prometheus Helm release.
     server: http://kube-prometheus-prometheus.kube-prometheus:9090
+    # If the Prometheus server is authorized, a secret containing the authentication header for the server
     auth:
       secret: null
       key: null
@@ -86,8 +92,8 @@ ssmsend:
 
   config:
     benchmarkValue: "15.0"
-    nodeCount: 0
-    processors: 0
+    nodeCount: "0"
+    processors: "0"
 
 gratia:
   resources:

--- a/python/KAPELConfig.py
+++ b/python/KAPELConfig.py
@@ -72,7 +72,6 @@ class KAPELConfig:
 
         # infrastructure info
         self.infrastructure_type = env.str("INFRASTRUCTURE_TYPE", "grid")
-        self.infrastructure_description = env.str("INFRASTRUCTURE_DESCRIPTION", "APEL-KUBERNETES")
 
         # optionally define number of nodes and processors. Should not be necessary to
         # set a default of 0 here but see https://github.com/apel/apel/issues/241


### PR DESCRIPTION
- Adds a values.yaml entry for every field previously controlled by the processor.config multiline string
- Split roughly as follows:
  - Prometheus server url and auth: `processor.prometheus`
  - Values that control query mode and interval: `processor.query`
  - Fields that are only used in summary-level APEL values (benchmark, processors, nodes): `ssmsend.config`
  - Everything else: `processor.config`

The helm chart currently falls back to the previous multiline string handling behavior if `processor.config` is a string instead of an object, which should hopefully make migration easier.