### PR TITLE
Replace multiline string configs in values.yaml with key/value pairs

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -56,6 +56,7 @@ below.
     * `SITE_NAME`: The name of the site being reported.
     * `SUBMIT_HOST`: Uniquely identifying name for the cluster.
     * `VO_NAME`: VO of jobs.
+    * `PROMETHEUS_SERVER`: Internal DNS name for the cluster's Prometheus instance
     * `BENCHMARK_VALUE`: The value to use for normalizing by CPU performance. Required for APEL accounting.
   * `.prometheus_auth`: If your Prometheus instance is configured to require [Authentication](https://prometheus.io/docs/prometheus/latest/configuration/https/)
     from within the cluster, specify a Secret containing a value for the authentication header.

--- a/chart/README.md
+++ b/chart/README.md
@@ -56,7 +56,7 @@ below.
     * `SITE_NAME`: The name of the site being reported.
     * `SUBMIT_HOST`: Uniquely identifying name for the cluster.
     * `VO_NAME`: VO of jobs.
-    * `PROMETHEUS_SERVER`: Internal DNS name for the cluster's Prometheus instance
+    * `PROMETHEUS_SERVER`: DNS name for the cluster's Prometheus instance. The default value works with a default installation of the bitnami/kube-prometheus Helm chart. Otherwise, for a Prometheus instance internal to the cluster, [construct](https://kubernetes.io/docs/concepts/services-networking/service/#dns) the URL based on the standard Kubernetes service discovery mechanism (i.e. service name and namespace).
     * `BENCHMARK_VALUE`: The value to use for normalizing by CPU performance. Required for APEL accounting.
   * `.prometheus_auth`: If your Prometheus instance is configured to require [Authentication](https://prometheus.io/docs/prometheus/latest/configuration/https/)
     from within the cluster, specify a Secret containing a value for the authentication header.

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -11,7 +11,3 @@ WARNING: processor.config.SITE_NAME is empty in values.yaml. Set it to the name 
 {{ if not .Values.processor.config.SUBMIT_HOST -}}
 WARNING: processor.config.SUBMIT_HOST is empty in values.yaml. Set it to a uniquely identifying domain name for this cluster.
 {{ end -}}
-
-{{ if not .Values.processor.config.VO_NAME -}}
-WARNING: processor.config.VO_NAME is empty in values.yaml. Set it to the Virtual Organization the site is participating in.
-{{ end -}}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,1 +1,17 @@
 1. The kapel accounting cron job should be running now. When the kapel pod runs check the logs of the processor and ssmsend containers.
+
+{{ if not .Values.processor.config.NAMESPACE  -}}
+WARNING: processor.config.NAMESPACE is empty in values.yaml. Set it to the namespace in the cluster where your workload jobs run.
+{{ end -}}
+
+{{ if not .Values.processor.config.SITE_NAME -}}
+WARNING: processor.config.SITE_NAME is empty in values.yaml. Set it to the name of the site being reported on.
+{{ end -}}
+
+{{ if not .Values.processor.config.SUBMIT_HOST -}}
+WARNING: processor.config.SUBMIT_HOST is empty in values.yaml. Set it to a uniquely identifying domain name for your cluster.
+{{ end -}}
+
+{{ if not .Values.processor.config.VO_NAME -}}
+WARNING: processor.config.VO_NAME is empty in values.yaml. Set it to the Virtual Organization 
+{{ end -}}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,17 +1,17 @@
 1. The kapel accounting cron job should be running now. When the kapel pod runs check the logs of the processor and ssmsend containers.
 
-{{ if not .Values.processor.config.NAMESPACE  -}}
-WARNING: processor.config.NAMESPACE is empty in values.yaml. Set it to the namespace in the cluster where your workload jobs run.
+{{ if not .Values.processor.config.NAMESPACE -}}
+WARNING: processor.config.NAMESPACE is empty in values.yaml. Set it to the namespace in the cluster where your workload pods run.
 {{ end -}}
 
 {{ if not .Values.processor.config.SITE_NAME -}}
-WARNING: processor.config.SITE_NAME is empty in values.yaml. Set it to the name of the site being reported on.
+WARNING: processor.config.SITE_NAME is empty in values.yaml. Set it to the name of the site this cluster is in.
 {{ end -}}
 
 {{ if not .Values.processor.config.SUBMIT_HOST -}}
-WARNING: processor.config.SUBMIT_HOST is empty in values.yaml. Set it to a uniquely identifying domain name for your cluster.
+WARNING: processor.config.SUBMIT_HOST is empty in values.yaml. Set it to a uniquely identifying domain name for this cluster.
 {{ end -}}
 
 {{ if not .Values.processor.config.VO_NAME -}}
-WARNING: processor.config.VO_NAME is empty in values.yaml. Set it to the Virtual Organization 
+WARNING: processor.config.VO_NAME is empty in values.yaml. Set it to the Virtual Organization the site is participating in.
 {{ end -}}

--- a/chart/templates/gratia-output-config.yaml
+++ b/chart/templates/gratia-output-config.yaml
@@ -6,5 +6,7 @@ metadata:
   labels:
     {{- include "kapel.labels" . | nindent 4 }}
 data:
-{{ .Values.gratia.config | indent 2 }}
+{{- range $key, $value := .Values.gratia.config }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
 {{ end }}

--- a/chart/templates/processor-config.yaml
+++ b/chart/templates/processor-config.yaml
@@ -5,4 +5,6 @@ metadata:
   labels:
     {{- include "kapel.labels" . | nindent 4 }}
 data:
-{{ .Values.processor.config | indent 2 }}
+{{- range $key, $value := .Values.processor.config }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -47,13 +47,20 @@ processor:
     requests:
       cpu: "0.5"
       memory: "500Mi"
-  # See KAPELConfig.py for full details on required configuration.
-  config: |
+  # Config values for the processor initContainer. See KAPELConfig.py for full details on required configuration.
+  config:
+    # Name of the site being reported on
     SITE_NAME: "EXAMPLE-T2"
+    # Uniquely identifying name for the cluster
     SUBMIT_HOST: "k8s.example.org:6443/namespace"
-    #BENCHMARK_VALUE: "15.0"
-    #NAMESPACE: "harvester"
-    #VO_NAME: "atlas"
+    # Namespace in the cluster where pilot jobs run
+    NAMESPACE: "example-namespace"
+    # Virtual Organization Name
+    VO_NAME: "example-vo"
+    # Cluster-internal DNS name for the cluster's Prometheus server
+    PROMETHEUS_SERVER: "http://kube-prometheus-prometheus.kube-prometheus:9090"
+    # Value to use for normalizing by CPU performance. Required for ssmsend output mode only
+    BENCHMARK_VALUE: "15.0"
 
   # Authentication secret for Prometheus, if any
   prometheus_auth:
@@ -92,9 +99,9 @@ gratia:
   image_repository: "hub.opensciencegrid.org/osgpreview/kapel-gratia-output"
   # Optionally overwrite container version. Default is chart appVersion.
   image_tag: ""
-  # Config options for Gratia. At present, only GRATIA_CONFIG_PATH can be specified,
-  # And points to the default Gratia config file.
-  config: |
+  # Config options for Gratia.
+  config: 
+    # Location of the Gratia probe config file. Can usually be kept as default
     GRATIA_CONFIG_PATH: "/etc/gratia/kubernetes/ProbeConfig"
 
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -50,11 +50,14 @@ processor:
   # Config values for the processor initContainer. See KAPELConfig.py for full details on required configuration.
   config:
     # Name of the site being reported on
-    SITE_NAME: "EXAMPLE-T2"
+    # SITE_NAME: "EXAMPLE-T2"
+    
     # Uniquely identifying name for the cluster
-    SUBMIT_HOST: "k8s.example.org:6443/namespace"
+    # SUBMIT_HOST: "k8s.example.org:6443/namespace"
+    
     # Namespace in the cluster where pilot jobs run
-    NAMESPACE: "example-namespace"
+    # NAMESPACE: "example-namespace"
+    
     # Virtual Organization Name
     VO_NAME: "example-vo"
     # Works for a default installation of the bitnami/kube-prometheus Helm chart, otherwise use http://<service>.<namespace>:<port>

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -55,7 +55,7 @@ processor:
     # Uniquely identifying name for the cluster
     # SUBMIT_HOST: "k8s.example.org:6443/namespace"
     
-    # Namespace in the cluster where pilot jobs run
+    # Namespace in the cluster where workload pods run
     # NAMESPACE: "example-namespace"
     
     # Virtual Organization Name
@@ -63,7 +63,7 @@ processor:
     # Works for a default installation of the bitnami/kube-prometheus Helm chart, otherwise use http://<service>.<namespace>:<port>
     PROMETHEUS_SERVER: "http://kube-prometheus-prometheus.kube-prometheus:9090"
     # Value to use for normalizing by CPU performance. Required for ssmsend output mode only
-    BENCHMARK_VALUE: "15.0"
+    #BENCHMARK_VALUE: "15.0"
 
   # Authentication secret for Prometheus, if any
   prometheus_auth:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -57,7 +57,7 @@ processor:
     NAMESPACE: "example-namespace"
     # Virtual Organization Name
     VO_NAME: "example-vo"
-    # Cluster-internal DNS name for the cluster's Prometheus server
+    # Works for a default installation of the bitnami/kube-prometheus Helm chart, otherwise use http://<service>.<namespace>:<port>
     PROMETHEUS_SERVER: "http://kube-prometheus-prometheus.kube-prometheus:9090"
     # Value to use for normalizing by CPU performance. Required for ssmsend output mode only
     BENCHMARK_VALUE: "15.0"

--- a/python/KAPELConfig.py
+++ b/python/KAPELConfig.py
@@ -11,9 +11,8 @@ class KAPELConfig:
         # Read a .env file if one is specified, otherwise only environment variables will be used.
         env.read_env(envFile, recurse=False, verbose=True)
 
-        # URL of the Prometheus server. Default value works within cluster for default bitnami/kube-prometheus Helm release.
-        # Format: validity is determined by python urllib.parse.
-        self.prometheus_server = env.url("PROMETHEUS_SERVER", "http://kube-prometheus-prometheus.kube-prometheus:9090").geturl()
+        # URL of the Prometheus server. The required format is based on python urllib.parse.
+        self.prometheus_server = env.url("PROMETHEUS_SERVER").geturl()
 
         # Optionally add authentication headers - these are passed in under "Authorization"
         self.auth_header = env.str("PROMETHEUS_AUTH_HEADER", None)


### PR DESCRIPTION
- Replace Multiline string configs in values.yaml with key/value pairs
- Add inline comments for important config values
- Add PROMETHEUS_SERVER to the default config, since it appears to vary per cluster/installation method