### PR TITLE
Assert that records being generated for Gratia have a nonzero processor count

### DIFF
--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -273,12 +273,12 @@ def record_individual_period(config, results):
             continue
         processors = records.get('cores', 0) or config.processors
         assert processors > 0, \
-            "must specify pilot CPU count via pod resource requests, or PROCESSORS config var"
+            "must specify core count via pod resource requests or PROCESSORS config var"
         individual_output = individual_message(
             config, 
             pod_name,
             records.get('memory', 0),
-            records.get('cores', 0),
+            processors,
             records['endtime'] - records['starttime'],
             records.get('cpuusage', 0),
             records['starttime'],

--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -271,6 +271,9 @@ def record_individual_period(config, results):
         # Only report on pods that have completed. Running pods won't have an endtime
         if not ('starttime' in records and 'endtime' in records):
             continue
+        processors = records.get('cores', 0) or config.processors
+        assert processors > 0, \
+            "must specify pilot CPU count via pod resource requests, or PROCESSORS config var"
         individual_output = individual_message(
             config, 
             pod_name,


### PR DESCRIPTION
Per our discussions with the GRACC dev team, Gratia records should have processors set to a nonzero value