### PR TITLE
Bump release version from 1.0.0-rc1 to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# KAPEL 
-KAPEL is container-native Kubernetes accounting, for APEL and Gratia.
+# Kuantifier
+Kuantifier (previously known as KAPEL) is container-native Kubernetes accounting, for APEL and Gratia.
 - Lightweight and stateless (data storage is handled by Prometheus).
 - Supports two publishing modes:
   - "auto" mode to publish the current month and previous month.
@@ -34,10 +34,9 @@ To do accounting for different projects in multiple namespaces, a KAPEL chart ca
 
 ## Configuration
 - See [kube-prometheus-example.yaml](docs/kube-prometheus-example.yaml) for an example values file to use for installation of the Bitnami kube-prometheus Helm chart.
-- See [values.yaml](chart/values.yaml) for the configurable values of the KAPEL Helm chart.
-- See [KAPELConfig.py](python/KAPELConfig.py) for descriptions of the settings used in KAPEL.
+- See [values.yaml](chart/values.yaml) for the configurable values of the Kuantifier Helm chart.
+- See [KAPELConfig.py](python/KAPELConfig.py) for descriptions of the settings used in Kuantifier.
 
 ## Helm chart installation
-The KAPEL Helm chart is available from [this Helm repository](https://rptaylor.github.io/kapel/).
 
-See the [Helm Chart README](chart/README.md) for additional information.
+See the [Helm Chart README](chart/README.md) for details on installing the Helm chart.

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0-rc1
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   kapel-processor:
-    image: hub.opensciencegrid.org/osgpreview/kapel-processor:latest
+    image: hub.opensciencegrid.org/iris-hep/kuantifier-processor:1.0.0
     build:
       context: .
       network: host


### PR DESCRIPTION
NOTE: this includes the [breaking change](https://github.com/rptaylor/kapel/pull/65/files#diff-a9d07052701ab3b718c82ac0fe74b965a8260b06bb5906362081718b0ee593b4L97) in config file format.