### PR TITLE
refine label filtering for cputime query

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.1
+version: 1.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -49,7 +49,7 @@ containerSecurityContext:
 processor:
   image_repository: "hub.opensciencegrid.org/iris-hep/kuantifier-processor"
   # Optionally overwrite container version.
-  image_tag: "1.0.1"
+  image_tag: "1.0.2"
   image_pull_policy: "IfNotPresent"
   resources:
     # very generous estimate: approx 10 KiB memory per job record

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   kapel-processor:
-    image: hub.opensciencegrid.org/iris-hep/kuantifier-processor:1.0.1
+    image: hub.opensciencegrid.org/iris-hep/kuantifier-processor:1.0.2
     build:
       context: .
       network: host


### PR DESCRIPTION
While migrating from bitnami's kube-prometheus to kube-prometheus-stack we found a new case that can produce matching errors due to duplicate records:
```
Processing year 2025, month 5, querying from 2025-05-29T21:36:58+00:00 and going back 2497018 s to 2025-05-01T00:00:00+00:00.
Executing cputime query: (max_over_time(kube_pod_completion_time{namespace="harvester"}[2497018s]) - max_over_time(kube_pod_start_time{namespace="harvester"}[2497018s])) * on (pod) group_left() max without (instance, node) (max_over_time(kube_pod_container_resource_requests{resource="cpu", node != "", namespace="harvester"}[2497018s]))
Traceback (most recent call last):
  File "/src/KAPEL.py", line 372, in <module>
    main(args.env_file)
  File "/src/KAPEL.py", line 365, in main
    process_period(config=cfg, period=p)
  File "/src/KAPEL.py", line 324, in process_period
    raw_result = prom.custom_query(query=query_string, params=prom_connect_params)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/prometheus_api_client/prometheus_connect.py", line 411, in custom_query
    raise PrometheusApiClientException(
prometheus_api_client.exceptions.PrometheusApiClientException: HTTP Status Code 422 (b'{"status":"error","errorType":"execution","error":"found duplicate series for the match group {pod=\\"grid-job-21859397-42q6d\\"} on the right hand-side of the operation: [{container=\\"job-container\\", endpoint=\\"http\\", job=\\"kube-state-metrics\\", namespace=\\"harvester\\", pod=\\"grid-job-21859397-42q6d\\", resource=\\"cpu\\", service=\\"kube-prometheus-stack-kube-state-metrics\\", uid=\\"675f3bae-83fd-4cc0-a764-8f80f087d9bb\\", unit=\\"core\\"}, {container=\\"job-container\\", endpoint=\\"http\\", job=\\"kube-prometheus-kube-state-metrics\\", namespace=\\"harvester\\", pod=\\"grid-job-21859397-42q6d\\", resource=\\"cpu\\", service=\\"kube-prometheus-kube-state-metrics\\", uid=\\"675f3bae-83fd-4cc0-a764-8f80f087d9bb\\", unit=\\"core\\"}];many-to-many matching not allowed: matching labels must be unique on one side"}')
```
The two monitoring stacks use different 'job' and 'service' labels.

- use `max by (pod, uid)` instead of `max without (instance, node)` to more comprehensively exclude spurious labels
- revise comments explaining this stuff
